### PR TITLE
Remove click constraint to fix make upgrade job

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ asgiref==3.5.0
     # via django
 billiard==3.6.4.0
     # via celery
-celery==5.0.4
+celery==5.2.3
     # via
     #   edx-celeryutils
     #   event-tracking
@@ -20,11 +20,10 @@ certifi==2021.10.8
     # via requests
 cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -40,7 +39,7 @@ code-annotations==1.2.0
     # via edx-toggles
 cryptography==36.0.1
     # via djfernet
-django==3.2.11
+django==3.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -71,12 +70,12 @@ djfernet==0.7.3
     # via -r requirements/base.in
 edx-celeryutils==1.2.1
     # via -r requirements/base.in
-edx-django-utils==4.4.2
+edx-django-utils==4.5.0
     # via
     #   django-config-models
     #   edx-toggles
     #   event-tracking
-edx-toggles==4.2.0
+edx-toggles==4.3.1
     # via -r requirements/base.in
 event-tracking==1.1.4
     # via -r requirements/base.in
@@ -100,7 +99,7 @@ newrelic==7.4.0.172
     # via edx-django-utils
 pbr==5.8.0
     # via stevedore
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.26
     # via click-repl
 psutil==5.9.0
     # via edx-django-utils
@@ -149,3 +148,6 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,11 +6,11 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.3
+coverage==6.3.1
     # via codecov
 distlib==0.3.4
     # via virtualenv

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,6 +19,3 @@ diff-cover==4.0.0
 
 # greater version failing docs build
 sphinx==4.2.0
-
-# Using the same version as of edx-celeryutils as it constraints click to version 7.1.2
-click==7.1.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,7 +29,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/quality.txt
     #   celery
-celery==5.0.4
+celery==5.2.3
     # via
     #   -r requirements/quality.txt
     #   edx-celeryutils
@@ -43,14 +43,13 @@ cffi==1.15.0
     # via
     #   -r requirements/quality.txt
     #   cryptography
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   celery
@@ -84,7 +83,7 @@ code-annotations==1.2.0
     #   edx-toggles
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.3
+coverage[toml]==6.3.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -104,7 +103,7 @@ distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.11
+django==3.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -142,7 +141,7 @@ djfernet==0.7.3
     # via -r requirements/quality.txt
 edx-celeryutils==1.2.1
     # via -r requirements/quality.txt
-edx-django-utils==4.4.2
+edx-django-utils==4.5.0
     # via
     #   -r requirements/quality.txt
     #   django-config-models
@@ -152,13 +151,13 @@ edx-i18n-tools==0.8.1
     # via -r requirements/dev.in
 edx-lint==5.2.1
     # via -r requirements/quality.txt
-edx-toggles==4.2.0
+edx-toggles==4.3.1
     # via -r requirements/quality.txt
 event-tracking==1.1.4
     # via -r requirements/quality.txt
 factory-boy==3.2.1
     # via -r requirements/quality.txt
-faker==11.3.0
+faker==12.0.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
@@ -176,7 +175,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-inflect==5.3.0
+inflect==5.4.0
     # via jinja2-pluralize
 iniconfig==1.1.1
     # via
@@ -255,7 +254,7 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.26
     # via
     #   -r requirements/quality.txt
     #   click-repl
@@ -370,7 +369,6 @@ stevedore==3.5.0
 text-unidecode==1.3
     # via
     #   -r requirements/quality.txt
-    #   faker
     #   python-slugify
 tincan==1.0.0
     # via -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -30,7 +30,7 @@ billiard==3.6.4.0
     #   celery
 bleach==4.1.0
     # via readme-renderer
-celery==5.0.4
+celery==5.2.3
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -43,13 +43,12 @@ cffi==1.15.0
     # via
     #   -r requirements/test.txt
     #   cryptography
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via
     #   -r requirements/test.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
@@ -72,7 +71,7 @@ code-annotations==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
-coverage[toml]==6.3
+coverage[toml]==6.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -82,7 +81,7 @@ cryptography==36.0.1
     #   djfernet
 ddt==1.4.4
     # via -r requirements/test.txt
-django==3.2.11
+django==3.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -127,7 +126,7 @@ docutils==0.17.1
     #   sphinx
 edx-celeryutils==1.2.1
     # via -r requirements/test.txt
-edx-django-utils==4.4.2
+edx-django-utils==4.5.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -135,13 +134,13 @@ edx-django-utils==4.4.2
     #   event-tracking
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-edx-toggles==4.2.0
+edx-toggles==4.3.1
     # via -r requirements/test.txt
 event-tracking==1.1.4
     # via -r requirements/test.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==11.3.0
+faker==12.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -198,7 +197,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.26
     # via
     #   -r requirements/test.txt
     #   click-repl
@@ -306,7 +305,6 @@ stevedore==3.5.0
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt
-    #   faker
     #   python-slugify
 tincan==1.0.0
     # via -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,10 +4,8 @@
 #
 #    make upgrade
 #
-click==7.1.2
-    # via
-    #   -c requirements/constraints.txt
-    #   pip-tools
+click==8.0.3
+    # via pip-tools
 pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==22.0.2
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -28,7 +28,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
-celery==5.0.4
+celery==5.2.3
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -41,13 +41,12 @@ cffi==1.15.0
     # via
     #   -r requirements/test.txt
     #   cryptography
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via
     #   -r requirements/test.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
@@ -75,7 +74,7 @@ code-annotations==1.2.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==6.3
+coverage[toml]==6.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -85,7 +84,7 @@ cryptography==36.0.1
     #   djfernet
 ddt==1.4.4
     # via -r requirements/test.txt
-django==3.2.11
+django==3.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -122,7 +121,7 @@ djfernet==0.7.3
     # via -r requirements/test.txt
 edx-celeryutils==1.2.1
     # via -r requirements/test.txt
-edx-django-utils==4.4.2
+edx-django-utils==4.5.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -130,13 +129,13 @@ edx-django-utils==4.4.2
     #   event-tracking
 edx-lint==5.2.1
     # via -r requirements/quality.in
-edx-toggles==4.2.0
+edx-toggles==4.3.1
     # via -r requirements/test.txt
 event-tracking==1.1.4
     # via -r requirements/test.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==11.3.0
+faker==12.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -198,7 +197,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.26
     # via
     #   -r requirements/test.txt
     #   click-repl
@@ -293,7 +292,6 @@ stevedore==3.5.0
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt
-    #   faker
     #   python-slugify
 tincan==1.0.0
     # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,7 +22,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.0.4
+celery==5.2.3
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -35,13 +35,12 @@ cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via
     #   -r requirements/base.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   click-didyoumean
@@ -65,7 +64,7 @@ code-annotations==1.2.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==6.3
+coverage[toml]==6.3.1
     # via pytest-cov
 cryptography==36.0.1
     # via
@@ -109,19 +108,19 @@ djfernet==0.7.3
     # via -r requirements/base.txt
 edx-celeryutils==1.2.1
     # via -r requirements/base.txt
-edx-django-utils==4.4.2
+edx-django-utils==4.5.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
     #   edx-toggles
     #   event-tracking
-edx-toggles==4.2.0
+edx-toggles==4.3.1
     # via -r requirements/base.txt
 event-tracking==1.1.4
     # via -r requirements/base.txt
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==11.3.0
+faker==12.0.0
     # via factory-boy
 future==0.18.2
     # via
@@ -165,7 +164,7 @@ pbr==5.8.0
     #   stevedore
 pluggy==1.0.0
     # via pytest
-prompt-toolkit==3.0.24
+prompt-toolkit==3.0.26
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -234,7 +233,6 @@ stevedore==3.5.0
 text-unidecode==1.3
     # via
     #   -r requirements/base.txt
-    #   faker
     #   python-slugify
 tincan==1.0.0
     # via -r requirements/base.txt
@@ -256,3 +254,6 @@ wcwidth==0.2.5
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
## Description
`edx-celeryutils` has been upgraded and the required `click` constraint has been removed from it so the `click` constraint can be removed now to allow the `make upgrade` job to pass.