### PR TITLE
feat: whitelisted video complete event for xAPI backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[5.2.1]
+~~~~~~~
+
+* Added `video_complete` event to xAPI backend and fixed broken links in documentation
+
 [5.2.0]
 ~~~~~~~
 

--- a/event_routing_backends/settings/common.py
+++ b/event_routing_backends/settings/common.py
@@ -53,6 +53,8 @@ def plugin_settings(settings):
                                     'edx.video.loaded',
                                     'play_video',
                                     'edx.video.played',
+                                    'complete_video',
+                                    'edx.video.completed',
                                     'stop_video',
                                     'edx.video.stopped',
                                     'pause_video',


### PR DESCRIPTION
White listing `video_complete` event for xAPI backend.