### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	$(PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	$(PIP_COMPILE) -o requirements/base.txt requirements/base.in
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/doc.txt requirements/doc.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -155,7 +155,7 @@ edx-django-utils==5.0.0
     #   event-tracking
 edx-i18n-tools==0.9.1
     # via -r requirements/dev.in
-edx-lint==5.2.2
+edx-lint==5.2.3
     # via -r requirements/quality.txt
 edx-toggles==5.0.0
     # via -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -85,7 +85,6 @@ cryptography==37.0.2
     # via
     #   -r requirements/test.txt
     #   djfernet
-    #   secretstorage
 ddt==1.5.0
     # via -r requirements/test.txt
 django==3.2.13
@@ -171,10 +170,6 @@ iniconfig==1.1.1
     #   pytest
 isodate==0.6.1
     # via -r requirements/test.txt
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -184,7 +179,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-keyring==23.5.1
+keyring==23.6.0
     # via twine
 kombu==5.2.4
     # via
@@ -212,7 +207,7 @@ pbr==5.9.0
     #   stevedore
 pep517==0.12.0
     # via build
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
 pluggy==1.0.0
     # via
@@ -298,8 +293,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -131,7 +131,7 @@ edx-django-utils==5.0.0
     #   django-config-models
     #   edx-toggles
     #   event-tracking
-edx-lint==5.2.2
+edx-lint==5.2.3
     # via -r requirements/quality.in
 edx-toggles==5.0.0
     # via -r requirements/test.txt


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3457