### PR TITLE
fix: Update the slack invite link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Our real-time conversations are on Slack. You can request a `Slack invitation`_,
 
 For more information about these options, see the `Getting Help <https://openedx.org/getting-help>`__ page.
 
-.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 
 .. |pypi-badge| image:: https://img.shields.io/pypi/v/event-routing-backends.svg


### PR DESCRIPTION
Point to the openedx.org shortcut which we can update as needed.