### PR TITLE
Django 3.2.15 security patch update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ code-annotations==1.3.0
     # via edx-toggles
 cryptography==37.0.4
     # via djfernet
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -40,5 +40,5 @@ tox==3.25.1
     # via -r requirements/ci.in
 urllib3==1.26.11
     # via requests
-virtualenv==20.16.1
+virtualenv==20.16.2
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,3 +19,6 @@ diff-cover==4.0.0
 
 # greater version failing docs build
 sphinx==4.2.0
+
+# Sphinx==4.2.0 requires docutils <0.18 but doc8==1.0.0 needs it to be >=0.19
+doc8<1.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ astroid==2.11.7
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -113,7 +113,7 @@ distlib==0.3.5
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -185,7 +185,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-inflect==5.6.2
+inflect==6.0.0
     # via jinja2-pluralize
 iniconfig==1.1.1
     # via
@@ -245,7 +245,7 @@ pbr==5.9.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
@@ -280,12 +280,14 @@ py==1.11.0
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.8.0
+pycodestyle==2.9.0
     # via -r requirements/quality.txt
 pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
+pydantic==1.9.1
+    # via inflect
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.12.0
@@ -415,6 +417,7 @@ typing-extensions==4.3.0
     # via
     #   -r requirements/quality.txt
     #   astroid
+    #   pydantic
     #   pylint
 urllib3==1.26.11
     # via
@@ -427,7 +430,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.16.1
+virtualenv==20.16.2
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,7 +18,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -85,10 +85,9 @@ cryptography==37.0.4
     # via
     #   -r requirements/test.txt
     #   djfernet
-    #   secretstorage
 ddt==1.5.0
     # via -r requirements/test.txt
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -124,7 +123,9 @@ djangorestframework==3.13.1
 djfernet==0.8.1
     # via -r requirements/test.txt
 doc8==0.11.2
-    # via -r requirements/doc.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.in
 docutils==0.17.1
     # via
     #   doc8
@@ -171,10 +172,6 @@ iniconfig==1.1.1
     #   pytest
 isodate==0.6.1
     # via -r requirements/test.txt
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -210,7 +207,7 @@ pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pkginfo==1.8.3
     # via twine
@@ -298,8 +295,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.5.1
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.3
     # via pip-tools
 packaging==21.3
     # via build
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pip-tools==6.8.0
     # via -r requirements/pip-tools.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.2
+pip==22.2.1
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -20,7 +20,7 @@ astroid==2.11.7
     # via
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -88,7 +88,7 @@ ddt==1.5.0
     # via -r requirements/test.txt
 dill==0.3.5.1
     # via pylint
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -213,7 +213,7 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.8.0
+pycodestyle==2.9.0
     # via -r requirements/quality.in
 pycparser==2.21
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
 billiard==3.6.4.0
     # via


### PR DESCRIPTION
`Sphinx==4.2.0` requires `docutils <0.18` but `doc8==1.0.0` needs it to be `>=0.19`
Pinning doc8 to resolve dependency conflict and ran make upgrade to update dependencies.