### PR TITLE
fix: pin doc8 and docutils versions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ code-annotations==1.3.0
     # via edx-toggles
 cryptography==37.0.4
     # via djfernet
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -98,9 +98,9 @@ kombu==5.2.4
     # via celery
 markupsafe==2.1.1
     # via jinja2
-newrelic==7.16.0.178
+newrelic==8.0.0.179
     # via edx-django-utils
-pbr==5.9.0
+pbr==5.10.0
     # via stevedore
 prompt-toolkit==3.0.30
     # via click-repl
@@ -116,7 +116,7 @@ python-dateutil==2.8.2
     # via -r requirements/base.in
 python-slugify==6.1.2
     # via code-annotations
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   -r requirements/base.in
     #   celery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,11 +10,11 @@ charset-normalizer==2.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.4.2
+coverage==6.4.4
     # via codecov
 distlib==0.3.5
     # via virtualenv
-filelock==3.7.1
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
@@ -40,5 +40,5 @@ tox==3.25.1
     # via -r requirements/ci.in
 urllib3==1.26.11
     # via requests
-virtualenv==20.16.1
+virtualenv==20.16.3
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,3 +19,7 @@ diff-cover==4.0.0
 
 # greater version failing docs build
 sphinx==4.2.0
+# Sphinx requires docutils<0.18 && doc8<1.0.0
+# This pin can be removed once sphinx constraint is removed.
+docutils<0.18
+doc8<1.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ astroid==2.11.7
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -89,7 +89,7 @@ code-annotations==1.3.0
     #   edx-toggles
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.4.2
+coverage[toml]==6.4.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -99,7 +99,7 @@ cryptography==37.0.4
     # via
     #   -r requirements/quality.txt
     #   djfernet
-ddt==1.5.0
+ddt==1.6.0
     # via -r requirements/quality.txt
 diff-cover==4.0.0
     # via
@@ -113,7 +113,7 @@ distlib==0.3.5
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -167,11 +167,11 @@ event-tracking==2.1.0
     # via -r requirements/quality.txt
 factory-boy==3.2.1
     # via -r requirements/quality.txt
-faker==13.15.1
+faker==14.0.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
-filelock==3.7.1
+filelock==3.8.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -185,7 +185,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-inflect==5.6.2
+inflect==6.0.0
     # via jinja2-pluralize
 iniconfig==1.1.1
     # via
@@ -227,7 +227,7 @@ mccabe==0.7.0
     #   pylint
 mock==4.0.3
     # via -r requirements/quality.txt
-newrelic==7.16.0.178
+newrelic==8.0.0.179
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -241,11 +241,11 @@ packaging==21.3
     #   tox
 path==16.4.0
     # via edx-i18n-tools
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
@@ -280,15 +280,17 @@ py==1.11.0
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.8.0
+pycodestyle==2.9.1
     # via -r requirements/quality.txt
 pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
+pydantic==1.9.2
+    # via inflect
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
-pygments==2.12.0
+pygments==2.13.0
     # via diff-cover
 pylint==2.14.5
     # via
@@ -341,7 +343,7 @@ python-slugify==6.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   -r requirements/quality.txt
     #   celery
@@ -401,7 +403,7 @@ tomli==2.0.1
     #   pep517
     #   pylint
     #   pytest
-tomlkit==0.11.1
+tomlkit==0.11.4
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -415,6 +417,7 @@ typing-extensions==4.3.0
     # via
     #   -r requirements/quality.txt
     #   astroid
+    #   pydantic
     #   pylint
 urllib3==1.26.11
     # via
@@ -427,7 +430,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.16.1
+virtualenv==20.16.3
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,7 +18,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -77,7 +77,7 @@ code-annotations==1.3.0
     #   edx-toggles
 commonmark==0.9.1
     # via rich
-coverage[toml]==6.4.2
+coverage[toml]==6.4.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -85,10 +85,9 @@ cryptography==37.0.4
     # via
     #   -r requirements/test.txt
     #   djfernet
-    #   secretstorage
-ddt==1.5.0
+ddt==1.6.0
     # via -r requirements/test.txt
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -124,9 +123,12 @@ djangorestframework==3.13.1
 djfernet==0.8.1
     # via -r requirements/test.txt
 doc8==0.11.2
-    # via -r requirements/doc.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.in
 docutils==0.17.1
     # via
+    #   -c requirements/constraints.txt
     #   doc8
     #   readme-renderer
     #   restructuredtext-lint
@@ -147,7 +149,7 @@ event-tracking==2.1.0
     # via -r requirements/test.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==13.15.1
+faker==14.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -171,10 +173,6 @@ iniconfig==1.1.1
     #   pytest
 isodate==0.6.1
     # via -r requirements/test.txt
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -184,7 +182,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-keyring==23.7.0
+keyring==23.8.2
     # via twine
 kombu==5.2.4
     # via
@@ -196,7 +194,7 @@ markupsafe==2.1.1
     #   jinja2
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==7.16.0.178
+newrelic==8.0.0.179
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -206,11 +204,11 @@ packaging==21.3
     #   build
     #   pytest
     #   sphinx
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pkginfo==1.8.3
     # via twine
@@ -234,7 +232,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pygments==2.12.0
+pygments==2.13.0
     # via
     #   doc8
     #   readme-renderer
@@ -269,7 +267,7 @@ python-slugify==6.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   -r requirements/test.txt
     #   babel
@@ -282,7 +280,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==35.0
+readme-renderer==36.0
     # via twine
 requests==2.28.1
     # via
@@ -298,8 +296,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.5.1
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.3
     # via pip-tools
 packaging==21.3
     # via build
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pip-tools==6.8.0
     # via -r requirements/pip-tools.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.2
+pip==22.2.2
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -20,7 +20,7 @@ astroid==2.11.7
     # via
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -76,7 +76,7 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==6.4.2
+coverage[toml]==6.4.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -84,11 +84,11 @@ cryptography==37.0.4
     # via
     #   -r requirements/test.txt
     #   djfernet
-ddt==1.5.0
+ddt==1.6.0
     # via -r requirements/test.txt
 dill==0.3.5.1
     # via pylint
-django==3.2.14
+django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -139,7 +139,7 @@ event-tracking==2.1.0
     # via -r requirements/test.txt
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==13.15.1
+faker==14.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -183,7 +183,7 @@ mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==7.16.0.178
+newrelic==8.0.0.179
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -191,7 +191,7 @@ packaging==21.3
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -213,7 +213,7 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.8.0
+pycodestyle==2.9.1
     # via -r requirements/quality.in
 pycparser==2.21
     # via
@@ -264,7 +264,7 @@ python-slugify==6.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -309,7 +309,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.1
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
 billiard==3.6.4.0
     # via
@@ -66,13 +66,13 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==6.4.2
+coverage[toml]==6.4.4
     # via pytest-cov
 cryptography==37.0.4
     # via
     #   -r requirements/base.txt
     #   djfernet
-ddt==1.5.0
+ddt==1.6.0
     # via -r requirements/test.in
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -122,7 +122,7 @@ event-tracking==2.1.0
     # via -r requirements/base.txt
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==13.15.1
+faker==14.0.0
     # via factory-boy
 future==0.18.2
     # via
@@ -154,13 +154,13 @@ markupsafe==2.1.1
     #   jinja2
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==7.16.0.178
+newrelic==8.0.0.179
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
 packaging==21.3
     # via pytest
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -206,7 +206,7 @@ python-slugify==6.1.2
     # via
     #   -r requirements/base.txt
     #   code-annotations
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   -r requirements/base.txt
     #   celery


### PR DESCRIPTION
### Description
- `Sphinx` requires `docutils` and `doc8` pinned versions for the `make upgrade` job to pass.