### PR TITLE
fix: Remove id since this force PUT request instead of POST

### DIFF
--- a/event_routing_backends/processors/xapi/transformer.py
+++ b/event_routing_backends/processors/xapi/transformer.py
@@ -54,7 +54,6 @@ class XApiTransformer(BaseTransformerMixin):
             'actor': self.get_actor(),
             'context': self.get_context(),
             'timestamp': self.get_timestamp(),
-            'id': uuid.uuid4()
         }
 
     def get_actor(self):


### PR DESCRIPTION
## Description 
Tincan library is used to make the request to the LRS, however that labrary has this condition https://github.com/RusticiSoftware/TinCanPython/blob/3.x/tincan/remote_lrs.py#L196, since the id is always defined  the request will be PUT and the nelp LRS only accepts POST