### PR TITLE
feat: use appropriate externalId types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Use proper externalId types XAPI and CALIPER instead of LTI
 
 [5.2.2]
 ~~~~~~~

--- a/docs/event-mapping/Caliper_mapping.rst
+++ b/docs/event-mapping/Caliper_mapping.rst
@@ -2,71 +2,71 @@
 edx.course.enrollment.activated
 ===============================
 
-=================== ==========================================
+=================== ============================================
 Caliper Key         Value
-=================== ==========================================
+=================== ============================================
 type                Event
 Action              Activated
 ``Actor``
-id                  <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                  <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                Person
 ``Object``
 id                  <LMS_ROOT_URL>/course/<data [ course_id ]>
 type                CourseOffering
 name                <name of course-run>
 extensions [ mode ] <data [ mode ]>
-=================== ==========================================
+=================== ============================================
 
 edx.course.enrollment.deactivated
 =================================
 
-=================== ==========================================
+=================== ============================================
 Caliper Key         Value
-=================== ==========================================
+=================== ============================================
 type                Event
 Action              Deactivated
 ``Actor``
-id                  <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                  <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                Person
 ``Object``
 id                  <LMS_ROOT_URL>/course/<data [ course_id ]>
 type                CourseOffering
 name                <name of course-run>
 extensions [ mode ] <data [ mode ]>
-=================== ==========================================
+=================== ============================================
 
 edx.course.grade.passed.first_time
 ==================================
 
-=========== ==========================================
+=========== ============================================
 Caliper Key Value
-=========== ==========================================
+=========== ============================================
 type        Event
 Action      Completed
 ``Actor``
-id          <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id          <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type        Person
 ``Object``
 id          <LMS_ROOT_URL>/course/<data [ course_id ]>
 type        CourseOffering
 name        <name of course-run>
-=========== ==========================================
+=========== ============================================
 
 problem_check event_source_server
 ====================================
 
-================================ ================================================================================================
+================================ ====================================================================================================
 Caliper Key                      Value
-================================ ================================================================================================
+================================ ====================================================================================================
 type                             GradeEvent
 Action                           Graded
 ``Actor``
-id                               <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                               <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                             Person
 ``Object``
-id                               <LMS_ROOT_URL>/xblock/<data [ problem_id ]> /user/<external_id[ LTI ]>/attempt/data [ attempts ]
+id                               <LMS_ROOT_URL>/xblock/<data [ problem_id ]> /user/<external_id[ CALIPER ]>/attempt/data [ attempts ]
 type                             Attempt
-assignee [ id ]                  <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+assignee [ id ]                  <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 assignee [ type ]                Person
 assignable [ id ]                <LMS_ROOT_URL>/xblock/<data [ problem_id ]>
 assignable [ type ]              Assessment
@@ -80,25 +80,25 @@ score [ maxScore ]                <data [ max_grade ] >
 score [ scoreGiven ]             < data [ grade ] >
 score [ attempt ]                < data [ attempts ] >
 score [ extensions [ success ] ] TRUE if < data [success] >  == "correct" else FALSE
-================================ ================================================================================================
+================================ ====================================================================================================
 
 problem_check event_source_browser
 =====================================
 
-=============== ===========================================
+=============== ============================================
 Caliper Key     Value
-=============== ===========================================
+=============== ============================================
 type            AssessmentEvent
 Action          Submitted
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              <LMS_ROOT_URL>/xblock/<data [ problem_id ]>
 type            Assessment
 isPartOf [id]   <LMS_ROOT_URL>/course/<data [ course_id ]>
 isPartOf [type] CourseOffering
-=============== ===========================================
+=============== ============================================
 
 showanswer
 ==========
@@ -109,7 +109,7 @@ Caliper Key                      Value
 type                             Event
 Action                           Viewed
 ``Actor``
-id                               <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                               <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                             Person
 ``Object``
 id                               <LMS_ROOT_URL>/xblock/<data [ problem_id ]>/solution
@@ -128,7 +128,7 @@ Caliper Key                      Value
 type                             Event
 Action                           Viewed
 ``Actor``
-id                               <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                               <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                             Person
 ``Object``
 id                               <LMS_ROOT_URL>/xblock/<data [ problem_id ]>/hint/ <data [ hint_index ] >
@@ -147,7 +147,7 @@ Caliper Key     Value
 type            MediaEvent
 Action          Started
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -166,7 +166,7 @@ Caliper Key     Value
 type            MediaEvent
 Action          Resumed
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -189,7 +189,7 @@ Caliper Key     Value
 type            MediaEvent
 Action          Ended
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -212,7 +212,7 @@ Caliper Key     Value
 type            MediaEvent
 Action          Paused
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -235,7 +235,7 @@ Caliper Key          Value
 type                 MediaEvent
 Action               JumpedTo
 ``Actor``
-id                   <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                   <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                 Person
 ``Object``
 id                   <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -259,7 +259,7 @@ Caliper Key     Value
 type            Event
 Action          Completed
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -278,7 +278,7 @@ Caliper Key          Value
 type                 MediaEvent
 Action               EnabledClosedCaptioning
 ``Actor``
-id                   <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                   <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                 Person
 ``Object``
 id                   <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -301,7 +301,7 @@ Caliper Key          Value
 type                 MediaEvent
 Action               DisabledClosedCaptioning
 ``Actor``
-id                   <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                   <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                 Person
 ``Object``
 id                   <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -324,7 +324,7 @@ Caliper Key          Value
 type                 MediaEvent
 Action               EnabledClosedCaptioning
 ``Actor``
-id                   <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                   <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                 Person
 ``Object``
 id                   <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -347,7 +347,7 @@ Caliper Key          Value
 type                 MediaEvent
 Action               DisabledClosedCaptioning
 ``Actor``
-id                   <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                   <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                 Person
 ``Object``
 id                   <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -370,7 +370,7 @@ Caliper Key            Value
 type                   MediaEvent
 Action                 ChangedSpeed
 ``Actor``
-id                     <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                     <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                   Person
 ``Object``
 id                     <LMS_ROOT_URL>/xblock/block-v1:<context [ course_id ] minus "course-v1:">+type@video+block@<data [ id ]>
@@ -389,13 +389,13 @@ extensions [newSpeed]   data [ new_speed ]
 edx.ui.lms.sequence.outline.selected
 ====================================
 
-=============== ==========================================
+=============== ============================================
 Caliper Key     Value
-=============== ==========================================
+=============== ============================================
 type            NavigationEvent
 Action          NavigatedTo
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              data [ target_url ]
@@ -403,18 +403,18 @@ type            DigitalResource
 name            data [ target_name ]
 isPartOf [id]   <LMS_ROOT_URL>/course/<data [ course_id ]>
 isPartOf [type] CourseOffering
-=============== ==========================================
+=============== ============================================
 
 edx.ui.lms.sequence.next_selected
 =================================
 
-========================== ==========================================
+========================== ============================================
 Caliper Key                Value
-========================== ==========================================
+========================== ============================================
 type                       NavigationEvent
 Action                     NavigatedTo
 ``Actor``
-id                         <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                         <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                       Person
 ``Object``
 id                         <LMS_ROOT_URL>/xblock/<data [ id ]>
@@ -425,18 +425,18 @@ isPartOf [type]            CourseOffering
 extensions [ target ]      "next unit"
 extensions [ current_tab ] data [current_tab]
 extensions [ tab_count ]   data [ tab_count ]
-========================== ==========================================
+========================== ============================================
 
 edx.ui.lms.sequence.previous_selected
 =====================================
 
-========================== ==========================================
+========================== ============================================
 Caliper Key                Value
-========================== ==========================================
+========================== ============================================
 type                       NavigationEvent
 Action                     NavigatedTo
 ``Actor``
-id                         <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                         <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                       Person
 ``Object``
 id                         <LMS_ROOT_URL>/xblock/<data [ id ]>
@@ -447,18 +447,18 @@ isPartOf [type]            CourseOffering
 extensions [ target ]      "previous unit"
 extensions [ current_tab ] data [current_tab]
 extensions [ tab_count ]   data [ tab_count ]
-========================== ==========================================
+========================== ============================================
 
 edx.ui.lms.sequence.tab_selected
 ================================
 
-========================== ==========================================
+========================== ============================================
 Caliper Key                Value
-========================== ==========================================
+========================== ============================================
 type                       NavigationEvent
 Action                     NavigatedTo
 ``Actor``
-id                         <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id                         <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type                       Person
 ``Object``
 id                         <LMS_ROOT_URL>/xblock/<data [ id ]>
@@ -469,22 +469,22 @@ isPartOf [type]            CourseOffering
 extensions [ target ]      data [ target_tab ]
 extensions [ current_tab ] data [current_tab]
 extensions [ tab_count ]   data [ tab_count ]
-========================== ==========================================
+========================== ============================================
 
 edx.ui.lms.link_clicked
 =======================
 
-=============== ==========================================
+=============== ============================================
 Caliper Key     Value
-=============== ==========================================
+=============== ============================================
 type            NavigationEvent
 Action          NavigatedTo
 ``Actor``
-id              <LMS_ROOT_URL>/user/<external_id[ LTI ]>
+id              <LMS_ROOT_URL>/user/<external_id[ CALIPER ]>
 type            Person
 ``Object``
 id              data [ target_url ]
 type            Webpage
 isPartOf [id]   <LMS_ROOT_URL>/course/<data [ course_id ]>
 isPartOf [type] CourseOffering
-=============== ==========================================
+=============== ============================================

--- a/docs/event-mapping/xAPI_mapping.rst
+++ b/docs/event-mapping/xAPI_mapping.rst
@@ -8,7 +8,7 @@ xAPI Key                                                                    Valu
 ``Actor``
 objectType                                                                  Agent
 account [ homePage ]                                                        <LMS_ROOT_URL>
-account [ name ]                                                            <external_id[ LTI ]>
+account [ name ]                                                            <external_id[ XAPI ]>
 ``Verb``
 id                                                                          http://adlnet.gov/expapi/verbs/registered
 display [ en-US ]                                                           registered
@@ -29,7 +29,7 @@ xAPI Key                                                                    Valu
 ``Actor``
 objectType                                                                  Agent
 account [ homePage ]                                                        <LMS_ROOT_URL>
-account [ name ]                                                            <external_id[ LTI ]>
+account [ name ]                                                            <external_id[ XAPI ]>
 ``Verb``
 id                                                                          http://id.tincanapi.com/verb/unregistered
 display [ en-US ]                                                           unregistered
@@ -50,7 +50,7 @@ xAPI Key                     Value
 ``Actor``
 objectType                   Agent
 account [ homePage ]         <LMS_ROOT_URL>
-account [ name ]             <external_id[ LTI ]>
+account [ name ]             <external_id[ XAPI ]>
 ``Verb``
 id                           http://adlnet.gov/expapi/verbs/passed
 display [ en-US ]            passed
@@ -69,7 +69,7 @@ xAPI Key                                                                   Value
 ``Actor``
 objectType                                                                 Agent
 account [ homePage ]                                                       <LMS_ROOT_URL>
-account [ name ]                                                           <external_id[ LTI ]>
+account [ name ]                                                           <external_id[ XAPI ]>
 ``Verb``
 id                                                                         https://w3id.org/xapi/acrossx/verbs/evaluated
 display [ en-US ]                                                          evaluated
@@ -125,7 +125,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            http://adlnet.gov/expapi/verbs/attempted
 display [ en-US ]                                             attempted
@@ -149,7 +149,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            http://adlnet.gov/expapi/verbs/asked
 display [ en-US ]                                             asked
@@ -173,7 +173,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            http://adlnet.gov/expapi/verbs/asked
 display [ en-US ]                                             asked
@@ -197,7 +197,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            http://adlnet.gov/expapi/verbs/initialized
 display [ en-US ]                                             initialized
@@ -222,7 +222,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            https://w3id.org/xapi/video/verbs/played
 display [ en-US ]                                             played
@@ -247,7 +247,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            http://adlnet.gov/expapi/verbs/terminated
 display [ en-US ]                                             terminated
@@ -274,7 +274,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            https://w3id.org/xapi/video/verbs/paused
 display [ en-US ]                                             paused
@@ -301,7 +301,7 @@ xAPI Key                                                        Value
 ``Actor``
 objectType                                                      Agent
 account [ homePage ]                                            <LMS_ROOT_URL>
-account [ name ]                                                <external_id[ LTI ]>
+account [ name ]                                                <external_id[ XAPI ]>
 ``Verb``
 id                                                              https://w3id.org/xapi/video/verbs/seeked
 display [ en-US ]                                               seeked
@@ -329,7 +329,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            https://w3id.org/xapi/dod-isd/verbs/completed
 display [ en-US ]                                             completed
@@ -354,7 +354,7 @@ xAPI Key                                                          Value
 ``Actor``
 objectType                                                        Agent
 account [ homePage ]                                              <LMS_ROOT_URL>
-account [ name ]                                                  <external_id[ LTI ]>
+account [ name ]                                                  <external_id[ XAPI ]>
 ``Verb``
 id                                                                https://w3id.org/xapi/video/verbs/interacted
 display [ en-US ]                                                 interacted
@@ -382,7 +382,7 @@ xAPI Key                                                          Value
 ``Actor``
 objectType                                                        Agent
 account [ homePage ]                                              <LMS_ROOT_URL>
-account [ name ]                                                  <external_id[ LTI ]>
+account [ name ]                                                  <external_id[ XAPI ]>
 ``Verb``
 id                                                                https://w3id.org/xapi/video/verbs/interacted
 display [ en-US ]                                                 interacted
@@ -410,7 +410,7 @@ xAPI Key                                                          Value
 ``Actor``
 objectType                                                        Agent
 account [ homePage ]                                              <LMS_ROOT_URL>
-account [ name ]                                                  <external_id[ LTI ]>
+account [ name ]                                                  <external_id[ XAPI ]>
 ``Verb``
 id                                                                https://w3id.org/xapi/video/verbs/interacted
 display [ en-US ]                                                 interacted
@@ -438,7 +438,7 @@ xAPI Key                                                          Value
 ``Actor``
 objectType                                                        Agent
 account [ homePage ]                                              <LMS_ROOT_URL>
-account [ name ]                                                  <external_id[ LTI ]>
+account [ name ]                                                  <external_id[ XAPI ]>
 ``Verb``
 id                                                                https://w3id.org/xapi/video/verbs/interacted
 display [ en-US ]                                                 interacted
@@ -466,7 +466,7 @@ xAPI Key                                                          Value
 ``Actor``
 objectType                                                        Agent
 account [ homePage ]                                              <LMS_ROOT_URL>
-account [ name ]                                                  <external_id[ LTI ]>
+account [ name ]                                                  <external_id[ XAPI ]>
 ``Verb``
 id                                                                https://w3id.org/xapi/video/verbs/interacted
 display [ en-US ]                                                 interacted
@@ -494,7 +494,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            https://w3id.org/xapi/dod-isd/verbs/navigated
 display [ en-US ]                                             Navigated
@@ -519,7 +519,7 @@ xAPI Key                                                                        
 ``Actor``
 objectType                                                                         Agent
 account [ homePage ]                                                               <LMS_ROOT_URL>
-account [ name ]                                                                   <external_id[ LTI ]>
+account [ name ]                                                                   <external_id[ XAPI ]>
 ``Verb``
 id                                                                                 https://w3id.org/xapi/dod-isd/verbs/navigated
 display [ en-US ]                                                                  Navigated
@@ -546,7 +546,7 @@ xAPI Key                                                                        
 ``Actor``
 objectType                                                                         Agent
 account [ homePage ]                                                               <LMS_ROOT_URL>
-account [ name ]                                                                   <external_id[ LTI ]>
+account [ name ]                                                                   <external_id[ XAPI ]>
 ``Verb``
 id                                                                                 https://w3id.org/xapi/dod-isd/verbs/navigated
 display [ en-US ]                                                                  Navigated
@@ -573,7 +573,7 @@ xAPI Key                                                                        
 ``Actor``
 objectType                                                                         Agent
 account [ homePage ]                                                               <LMS_ROOT_URL>
-account [ name ]                                                                   <external_id[ LTI ]>
+account [ name ]                                                                   <external_id[ XAPI ]>
 ``Verb``
 id                                                                                 https://w3id.org/xapi/dod-isd/verbs/navigated
 display [ en-US ]                                                                  Navigated
@@ -600,7 +600,7 @@ xAPI Key                                                      Value
 ``Actor``
 objectType                                                    Agent
 account [ homePage ]                                          <LMS_ROOT_URL>
-account [ name ]                                              <external_id[ LTI ]>
+account [ name ]                                              <external_id[ XAPI ]>
 ``Verb``
 id                                                            https://w3id.org/xapi/dod-isd/verbs/navigated
 display [ en-US ]                                             Navigated

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -22,7 +22,7 @@ User = get_user_model()
 UTC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
 
-def get_anonymous_user_id(username_or_id):
+def get_anonymous_user_id(username_or_id, external_type):
     """
     Generate anonymous user id.
 
@@ -31,6 +31,7 @@ def get_anonymous_user_id(username_or_id):
 
     Arguments:
         username_or_id (str):     username for the learner
+        external_type  (str):     external type id e.g caliper or xapi
 
     Returns:
         str
@@ -53,7 +54,7 @@ def get_anonymous_user_id(username_or_id):
 
         anonymous_id = str(uuid4())
     else:
-        type_name = ExternalIdType.LTI
+        type_name = getattr(ExternalIdType, external_type)
         external_id, _ = ExternalId.add_new_user_id(user, type_name)
         if not external_id:
             raise ValueError("External ID type: %s does not exist" % type_name)

--- a/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
@@ -135,7 +135,7 @@ class ProblemEventsTransformers(CaliperTransformer):
             )
         key = self.get_event_name_key()
 
-        anonymous_user_id = get_anonymous_user_id(self.extract_username_or_userid())
+        anonymous_user_id = get_anonymous_user_id(self.extract_username_or_userid(), 'CALIPER')
         if key == 'showanswer':
             iri_url = '{}/solution'.format(object_id)
         elif key == 'edx.problem.hint.demandhint_displayed':

--- a/event_routing_backends/processors/caliper/transformer.py
+++ b/event_routing_backends/processors/caliper/transformer.py
@@ -56,7 +56,7 @@ class CaliperTransformer(BaseTransformerMixin):
         self.transformed_event['actor'] = {
             'id': self.get_object_iri(
                 'user',
-                get_anonymous_user_id(self.extract_username_or_userid()),
+                get_anonymous_user_id(self.extract_username_or_userid(), 'CALIPER'),
             ),
             'type': 'Person'
         }

--- a/event_routing_backends/processors/xapi/transformer.py
+++ b/event_routing_backends/processors/xapi/transformer.py
@@ -65,7 +65,7 @@ class XApiTransformer(BaseTransformerMixin):
             `Agent`
         """
 
-        user_uuid = get_anonymous_user_id(self.extract_username_or_userid())
+        user_uuid = get_anonymous_user_id(self.extract_username_or_userid(), 'XAPI')
         return Agent(
             account={"homePage": settings.LMS_ROOT_URL, "name": user_uuid}
         )

--- a/event_routing_backends/tests/test_helpers.py
+++ b/event_routing_backends/tests/test_helpers.py
@@ -29,6 +29,6 @@ class TestHelpers(TestCase):
     def test_get_anonymous_user_id_with_error(self, mocked_external_id):
         mocked_external_id.add_new_user_id.return_value = (None, False)
         with self.assertRaises(ValueError):
-            get_anonymous_user_id('edx')
+            get_anonymous_user_id('edx', 'XAPI')
 
-        self.assertIsNotNone(get_anonymous_user_id('12345678'))
+        self.assertIsNotNone(get_anonymous_user_id('12345678', 'XAPI'))

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -21,7 +21,7 @@ def _mock_third_party_modules():
     external_id.external_user_id = '32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb'
     external_user_ids_module = mock.MagicMock()
     external_user_ids_module.ExternalId.add_new_user_id.return_value = (external_id, True)
-    external_user_ids_module.ExternalIdType.LTI = 'lti'
+    external_user_ids_module.ExternalIdType.XAPI = 'xapi'
     sys.modules['openedx.core.djangoapps.external_user_ids.models'] = external_user_ids_module
 
     # mock course


### PR DESCRIPTION
This PR has changes to use `LTI` and `CALIPER` externalId types instead of `LTI`.