### PR TITLE
feat: Make xAPI User Identifier configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Unreleased
 ~~~~~~~~~~
 
 * Use proper externalId types XAPI and CALIPER instead of LTI
+* Make user identifier in xAPI events configurable
 
 [5.2.2]
 ~~~~~~~

--- a/event_routing_backends/processors/tests/transformers_test_mixin.py
+++ b/event_routing_backends/processors/tests/transformers_test_mixin.py
@@ -41,7 +41,7 @@ class TransformersTestMixin:
     EXCEPTED_EVENTS_FIXTURES_PATH = None
 
     def setUp(self):
-        UserFactory.create(username='edx')
+        UserFactory.create(username='edx', email='edx@example.com')
 
     def get_raw_event(self, event_filename):
         """

--- a/event_routing_backends/settings/common.py
+++ b/event_routing_backends/settings/common.py
@@ -12,6 +12,33 @@ def plugin_settings(settings):
     settings.EVENT_ROUTING_BACKEND_MAX_RETRIES = 3
     settings.EVENT_ROUTING_BACKEND_COUNTDOWN = 30
 
+    # .. setting_name: XAPI_AGENT_IFI_TYPE
+    # .. setting_default: 'external_id'
+    # .. setting_description: This setting can be used to specify the type of inverse functional identifier
+    #    for actor in xAPI statements. Possible values are 'external_id', 'mbox_sha1sum' and 'mbox'
+    #    when we set it to 'external_id' xAPI statement would represent actor like this
+    #    ```
+    #    {
+    #        "objectType": "Agent",
+    #        "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}
+    #    }
+    #    ```
+    #    setting it to 'mbox' xAPI statement would represent actor like this
+    #    ```
+    #    {
+    #        "objectType": "Agent",
+    #        "mbox": "mailto:info@xapi.com"
+    #    }
+    #    ```
+    #    setting it to 'mbox_sha1sum' xAPI statement would represent actor like this
+    #    ```
+    #    {
+    #        "objectType": "Agent",
+    #        mbox_sha1sum: "f427d80dc332a166bf5f160ec15f009ce7e68c4c"
+    #    }
+    #    ```
+    settings.XAPI_AGENT_IFI_TYPE = 'external_id'
+
     # .. setting_name: EVENT_TRACKING_BACKENDS_BUSINESS_CRITICAL_EVENTS
     # .. setting_default: [
     #    'edx.course.enrollment.activated',

--- a/event_routing_backends/settings/production.py
+++ b/event_routing_backends/settings/production.py
@@ -31,3 +31,7 @@ def plugin_settings(settings):
         'EVENT_TRACKING_BACKENDS_BUSINESS_CRITICAL_EVENTS',
         settings.EVENT_TRACKING_BACKENDS_BUSINESS_CRITICAL_EVENTS
     )
+    settings.XAPI_AGENT_IFI_TYPE = settings.ENV_TOKENS.get(
+        'XAPI_AGENT_IFI_TYPE',
+        settings.XAPI_AGENT_IFI_TYPE
+    )

--- a/event_routing_backends/tests/test_helpers.py
+++ b/event_routing_backends/tests/test_helpers.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from event_routing_backends.helpers import get_anonymous_user_id, get_block_id_from_event_referrer
+from event_routing_backends.helpers import get_anonymous_user_id, get_block_id_from_event_referrer, get_user_email
 from event_routing_backends.tests.factories import UserFactory
 
 
@@ -15,7 +15,7 @@ class TestHelpers(TestCase):
     """
     def setUp(self):
         super().setUp()
-        UserFactory.create(username='edx')
+        UserFactory.create(username='edx', email='edx@example.com')
 
     def test_get_block_id_from_event_referrer_with_error(self):
         sample_event = {
@@ -24,6 +24,18 @@ class TestHelpers(TestCase):
             }
         }
         self.assertEqual(get_block_id_from_event_referrer(sample_event['context']['referer']), None)
+
+    def test_get_user_email(self):
+        with patch('event_routing_backends.helpers.get_potentially_retired_user_by_username') as mock_pr_user:
+            mock_pr_user.return_value = None
+            email = get_user_email('unknown')
+            self.assertEqual(email, 'unknown@example.com')
+        with patch('event_routing_backends.helpers.get_potentially_retired_user_by_username') as mock_pr_user:
+            mock_pr_user.side_effect = Exception('User not found')
+            email = get_user_email('unknown')
+            self.assertEqual(email, 'unknown@example.com')
+        email = get_user_email('edx')
+        self.assertEqual(email, 'edx@example.com')
 
     @patch('event_routing_backends.helpers.ExternalId')
     def test_get_anonymous_user_id_with_error(self, mocked_external_id):

--- a/test_settings.py
+++ b/test_settings.py
@@ -51,4 +51,6 @@ RUNNING_WITH_TEST_SETTINGS = True
 
 EVENT_TRACKING_BACKENDS = {}
 
+XAPI_AGENT_IFI_TYPE = 'external_id'
+
 _mock_third_party_modules()

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -37,6 +37,14 @@ def _mock_third_party_modules():
     mocked_keys = mock.MagicMock()
     sys.modules['opaque_keys.edx.keys'] = mocked_keys
 
+    # mock retired user
+    mocked_user = mock.MagicMock()
+    mocked_user.username = 'edx_retired'
+    mocked_user.email = 'edx_retired@example.com'
+    mocked_models = mock.MagicMock()
+    mocked_models.get_potentially_retired_user_by_username.return_value = mocked_user
+    sys.modules['common.djangoapps.student.models'] = mocked_models
+
 
 def mocked_course_reverse(_, kwargs):
     """


### PR DESCRIPTION
This PR has changes to make user identifier in xAPI events configurable. We have introduced a new setting `XAPI_AGENT_IFI_TYPE` to make it configurable.

This setting can be used to specify the type of inverse functional identifier for actor in xAPI statements. Possible values are `external_id`, `mbox_sha1sum` and `mbox`

when we set it to `external_id` xAPI statement would represent actor like this
```
{
"objectType": "Agent",
"account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}
}
```

setting it to `mbox` xAPI statement would represent actor like this
```
{
"objectType": "Agent",
"mbox": "mailto:info@xapi.com"
}
```

setting it to `mbox_sha1sum` xAPI statement would represent actor like this
```
{
"objectType": "Agent",
"mbox_sha1sum": "f427d80dc332a166bf5f160ec15f009ce7e68c4c"
}
```
Implements #258 