### PR TITLE
chore: Remove broken codecov requirement, run upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ click-repl==0.2.0
     # via celery
 code-annotations==1.3.0
     # via edx-toggles
-cryptography==39.0.2
+cryptography==40.0.1
     # via djfernet
 django==3.2.18
     # via
@@ -73,7 +73,7 @@ djfernet==0.8.1
     # via -r requirements/base.in
 edx-celeryutils==1.2.2
     # via -r requirements/base.in
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   django-config-models
     #   edx-toggles
@@ -96,7 +96,7 @@ kombu==5.2.4
     # via celery
 markupsafe==2.1.2
     # via jinja2
-newrelic==8.7.0
+newrelic==8.8.0
     # via edx-django-utils
 pbr==5.11.1
     # via stevedore
@@ -114,7 +114,7 @@ python-dateutil==2.8.2
     # via -r requirements/base.in
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.in
     #   celery

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests in Travis
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.1
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -38,7 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,15 +16,11 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   pytest
 billiard==3.6.4.0
     # via
     #   -r requirements/quality.txt
@@ -40,7 +36,6 @@ celery==5.2.7
     #   event-tracking
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 cffi==1.15.1
@@ -50,7 +45,6 @@ cffi==1.15.1
     #   pynacl
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 click==8.1.3
@@ -87,15 +81,11 @@ code-annotations==1.3.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   edx-toggles
-codecov==2.1.12
-    # via -r requirements/ci.txt
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/quality.txt
     #   djfernet
@@ -151,7 +141,7 @@ djfernet==0.8.1
     # via -r requirements/quality.txt
 edx-celeryutils==1.2.2
     # via -r requirements/quality.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/quality.txt
     #   django-config-models
@@ -171,21 +161,20 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/quality.txt
-faker==17.6.0
+faker==18.4.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
-filelock==3.9.1
+filelock==3.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-inflect==6.0.2
+inflect==6.0.4
     # via jinja2-pluralize
 iniconfig==2.0.0
     # via
@@ -227,11 +216,11 @@ mccabe==0.7.0
     #   pylint
 mock==5.0.1
     # via -r requirements/quality.txt
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -245,9 +234,9 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -280,13 +269,13 @@ pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pydantic==1.10.6
+pydantic==1.10.7
     # via inflect
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.0
     # via diff-cover
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -318,7 +307,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -335,7 +324,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   celery
@@ -349,10 +338,7 @@ pyyaml==6.0
     #   code-annotations
     #   edx-i18n-tools
 requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-    #   codecov
+    # via -r requirements/quality.txt
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -393,7 +379,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -412,7 +398,6 @@ typing-extensions==4.5.0
     #   pylint
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 vine==5.0.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,10 +18,6 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 babel==2.12.1
     # via sphinx
 billiard==3.6.4.0
@@ -75,15 +71,14 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/test.txt
     #   djfernet
-    #   secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
 django==3.2.18
@@ -134,7 +129,7 @@ docutils==0.17.1
     #   sphinx
 edx-celeryutils==1.2.2
     # via -r requirements/test.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -152,7 +147,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==17.6.0
+faker==18.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -162,7 +157,7 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   twine
@@ -176,10 +171,6 @@ isodate==0.6.1
     # via -r requirements/test.txt
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -207,11 +198,11 @@ mock==5.0.1
     # via -r requirements/test.txt
 more-itertools==9.1.0
     # via jaraco-classes
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   build
@@ -239,7 +230,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   readme-renderer
@@ -255,7 +246,7 @@ pynacl==1.5.0
     #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -272,7 +263,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel
@@ -299,10 +290,8 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,14 +16,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
@@ -76,11 +72,11 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/test.txt
     #   djfernet
@@ -125,7 +121,7 @@ djfernet==0.8.1
     # via -r requirements/test.txt
 edx-celeryutils==1.2.2
     # via -r requirements/test.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -143,7 +139,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==17.6.0
+faker==18.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -183,11 +179,11 @@ mccabe==0.7.0
     # via pylint
 mock==5.0.1
     # via -r requirements/test.txt
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -195,7 +191,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -217,7 +213,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -239,7 +235,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -256,7 +252,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   celery
@@ -301,7 +297,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,8 +16,6 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-attrs==22.2.0
-    # via pytest
 billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
@@ -66,9 +64,9 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via pytest-cov
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/base.txt
     #   djfernet
@@ -110,7 +108,7 @@ djfernet==0.8.1
     # via -r requirements/base.txt
 edx-celeryutils==1.2.2
     # via -r requirements/base.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -124,7 +122,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==17.6.0
+faker==18.4.0
     # via factory-boy
 idna==3.4
     # via
@@ -152,11 +150,11 @@ markupsafe==2.1.2
     #   jinja2
 mock==5.0.1
     # via -r requirements/test.in
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via pytest
 pbr==5.11.1
     # via
@@ -184,7 +182,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-cov
     #   pytest-django
@@ -200,7 +198,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   celery


### PR DESCRIPTION
**Description:** codecov pulled their entire PyPI project and everything broke. We didn't actually need it, since we're using the Github action to upload these days. Also running make upgrade to propagate the change.
