### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,7 @@ How To Contribute
 -----------------
 
 Contributions are very welcome.
-Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`__ for details.
-Even though they were written with ``edx-platform`` in mind, the guidelines
+Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`__ for details.
 should be followed for all Open edX projects.
 
 The pull request description template should be automatically applied if you are creating a pull request from GitHub. Otherwise you


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
