### PR TITLE
fix: Many retries when an LRS returns a 409 error

### DIFF
--- a/event_routing_backends/utils/xapi_lrs_client.py
+++ b/event_routing_backends/utils/xapi_lrs_client.py
@@ -78,7 +78,7 @@ class LrsClient:
             # Tincan doesn't gracefully handle the response code we get from an LRS
             # when the event id already exists, causing many retries that will never
             # succeed, so we can eat this here.
-            if response.response.status_code == 409:
+            if response.response.status == 409:
                 logger.info('Event {} received a 409 error indicating the event id already exists.'.format(event_name))
             else:
                 logger.warning('{} request failed for sending xAPI statement of edx event "{}" to {}. '

--- a/event_routing_backends/utils/xapi_lrs_client.py
+++ b/event_routing_backends/utils/xapi_lrs_client.py
@@ -75,7 +75,13 @@ class LrsClient:
 
         response = self.lrs_client.save_statement(statement_data)
         if not response.success:
-            logger.warning('{} request failed for sending xAPI statement of edx event "{}" to {}. '
-                           'Response code: {}. Response: {}'.format(response.request.method, event_name, self.URL,
-                                                                    response.response.code, response.data))
-            raise EventNotDispatched
+            # Tincan doesn't gracefully handle the response code we get from an LRS
+            # when the event id already exists, causing many retries that will never
+            # succeed, so we can eat this here.
+            if response.response.status_code == 409:
+                logger.info('Event {} received a 409 error indicating the event id already exists.'.format(event_name))
+            else:
+                logger.warning('{} request failed for sending xAPI statement of edx event "{}" to {}. '
+                               'Response code: {}. Response: {}'.format(response.request.method, event_name, self.URL,
+                                                                        response.response.code, response.data))
+                raise EventNotDispatched


### PR DESCRIPTION
**Description:** The 409 error code is returned when an LRS determines a statement id already exists in the database, which is a use case we will see a lot with the new idempotent statement ids and upcoming tracking log replay. This change logs and eats that error.

This was introduced here:
https://github.com/openedx/event-routing-backends/pull/290/files

**Issue:** https://github.com/openedx/event-routing-backends/issues/295

**Merge deadline:** ASAP as this has a multiplicative effect for each failing event which (in older versions) is compounded by this issue: https://github.com/openedx/event-routing-backends/issues/296

**Testing instructions:**
Currently this is easy to test in a Nutmeg Tutor install given the other issue with the idempotent ids. 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** This is a draft PR just to get @ziafazal 's eyes on it before I put more work into making the tests work. It may not be the correct way to go so I'd like his input.