### PR TITLE
fix: Allow LTI fallback on ExternalIdTypes for older edx-platform versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[5.3.1]
+~~~~~~~
+
+* Allow External ID type to fall back to LTI on older versions of edx-platform
+  to preserve backward compatibility
 
 [5.3.0]
 ~~~~~~~

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,6 +2,6 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '5.3.0'
+__version__ = '5.3.1'
 
 default_app_config = 'event_routing_backends.apps.EventRoutingBackendsConfig'  # pylint: disable=invalid-name

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -71,7 +71,7 @@ def get_anonymous_user_id(username_or_id, external_type):
         # usual type.
         try:
             type_name = getattr(ExternalIdType, external_type)
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             type_name = ExternalIdType.LTI
 
         external_id, _ = ExternalId.add_new_user_id(user, type_name)

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -63,7 +63,17 @@ def get_anonymous_user_id(username_or_id, external_type):
 
         anonymous_id = str(uuid.uuid4())
     else:
-        type_name = getattr(ExternalIdType, external_type)
+        # Older versions of edx-platform do not have the XAPI or
+        # Caliper ExternalIdTypes, so we fall back to LTI here.
+        # Eventually this will be a problem when those instances
+        # upgrade and their actor id's all change, unless we
+        # eventually add a setting to force LTI here instead of the
+        # usual type.
+        try:
+            type_name = getattr(ExternalIdType, external_type)
+        except AttributeError:
+            type_name = ExternalIdType.LTI
+
         external_id, _ = ExternalId.add_new_user_id(user, type_name)
         if not external_id:
             raise ValueError("External ID type: %s does not exist" % type_name)


### PR DESCRIPTION
**Description:** Older edx-platform versions don't have the XAPI and Caliper types, causing errors. This allows a graceful fallback.

**Issues:** #296 #297
 
**Testing instructions:**

1. Try to send an xAPI event on a Nutmeg server with e-r-b installed
2. Note the errors in the log: `Error: type object 'ExternalIdType' has no attribute 'XAPI'`

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** This solution is pretty hacky, we should really make a setting or something to force LTI type in case anyone using this wants to upgrade later and not have all of their actor ids change. Test isn't written to cover this try / catch, I'm not sure it's worth the time.
