### PR TITLE
fix: Caliper transform of video events without duration

### DIFF
--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,6 +2,6 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '5.5.0'
+__version__ = '5.5.1'
 
 default_app_config = 'event_routing_backends.apps.EventRoutingBackendsConfig'  # pylint: disable=invalid-name

--- a/event_routing_backends/processors/caliper/event_transformers/video_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/video_events.py
@@ -21,10 +21,6 @@ The (soon to be) updated event names are as following:
 - edx.video.position.changed
 - edx.video.completed (proposed)
 """
-from datetime import timedelta
-
-from isodate import duration_isoformat
-
 from event_routing_backends.helpers import convert_seconds_to_iso, make_video_block_id
 from event_routing_backends.processors.caliper.registry import CaliperTransformersRegistry
 from event_routing_backends.processors.caliper.transformer import CaliperTransformer
@@ -95,9 +91,9 @@ class BaseVideoTransformer(CaliperTransformer):
         caliper_object.update({
             'id': self.get_object_iri('xblock', object_id),
             'type': 'VideoObject',
-            'duration': duration_isoformat(timedelta(
-                    seconds=data.get('duration', 0)
-            ))
+            'duration': convert_seconds_to_iso(
+                seconds=data.get('duration', 0)
+            )
         })
 
         return caliper_object

--- a/event_routing_backends/processors/tests/fixtures/current/edx.video.closed_captions.hidden.null.duration.json
+++ b/event_routing_backends/processors/tests/fixtures/current/edx.video.closed_captions.hidden.null.duration.json
@@ -1,0 +1,27 @@
+{
+    "name": "edx.video.closed_captions.hidden",
+    "timestamp": "2022-11-16T08:05:01.963139+00:00",
+    "data": {
+        "id": "0b9e39477cf34507a7a48f74be381fdd",
+        "code": "html5",
+        "duration": null,
+        "current_time": 21.133524
+    },
+    "context": {
+        "session": "95522acebdda19758bd98a456a640afa",
+        "user_id": 19,
+        "username": "test",
+        "ip": "172.20.0.1",
+        "host": "localhost:18000",
+        "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36",
+        "path": "/event",
+        "referer": "http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view",
+        "accept_language": "en-US,en;q=0.9",
+        "client_id": "1309536091.1619499525",
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "org_id": "edX",
+        "enterprise_uuid": "",
+        "event_source": "browser",
+        "page": "http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view"
+    }
+}


### PR DESCRIPTION
**Description:** Fixes https://github.com/openedx/event-routing-backends/issues/310 which was reported here: https://github.com/openedx/event-routing-backends/pull/301#pullrequestreview-1487368033

**Author concerns:** I wasn't able to test this, or write a new test for it since it seems like an existing test should have already caught this. I'm not quite sure what the difference was in @ziafazal 's test, but this change seems harmless and obviously worked for him.
