### PR TITLE
fix: Divide by 0 errors on problem interaction events

### DIFF
--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '5.5.2'
+__version__ = '5.5.3'

--- a/event_routing_backends/processors/tests/fixtures/current/edx.grades.problem.submitted.weighted_possible_0.json
+++ b/event_routing_backends/processors/tests/fixtures/current/edx.grades.problem.submitted.weighted_possible_0.json
@@ -1,0 +1,32 @@
+{
+    "context": {
+        "accept_language": "en-US,en;q=0.9",
+        "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
+        "client_id": "667522224.1583394645",
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "course_user_tags": {},
+        "host": "localhost:18000",
+        "ip": "172.18.0.1",
+        "module": {
+            "display_name": "Checkboxes",
+            "usage_key": "block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66"
+        },
+        "org_id": "edX",
+        "path": "/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66/handler/xmodule_handler/problem_check",
+        "referer": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/8b66dcd2d6134eda9355089ece4f39f6/ef37eb3cf1724e38b7f88a9ce85a4842/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40ef37eb3cf1724e38b7f88a9ce85a4842",
+        "session": "993110e9c27848a545da74a74114158d",
+        "user_id": 3,
+        "username": "edx"
+    },
+    "data": {
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "event_transaction_id": "07adb7b7-db7e-4cfd-9d69-5474a4c5774c",
+        "event_transaction_type": "edx.grades.problem.submitted",
+        "problem_id": "block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66",
+        "user_id": "3",
+        "weighted_earned": 0,
+        "weighted_possible": 0
+    },
+    "name": "edx.grades.problem.submitted",
+    "timestamp": "2020-07-15T05:59:29.700909+00:00"
+}

--- a/event_routing_backends/processors/tests/fixtures/current/problem_check(server).max_grade_0.json
+++ b/event_routing_backends/processors/tests/fixtures/current/problem_check(server).max_grade_0.json
@@ -1,0 +1,91 @@
+{
+    "context": {
+        "accept_language": "en-US,en;q=0.9",
+        "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
+        "asides": {},
+        "client_id": "667522224.1583394645",
+        "course_id": "course-v1:edX+DemoX+Demo_Course",
+        "course_user_tags": {},
+        "event_source": "server",
+        "host": "localhost:18000",
+        "ip": "172.18.0.1",
+        "module": {
+            "display_name": "Checkboxes",
+            "usage_key": "block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66"
+        },
+        "org_id": "edX",
+        "page": "x_module",
+        "path": "/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66/handler/xmodule_handler/problem_check",
+        "referer": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/8b66dcd2d6134eda9355089ece4f39f6/ef37eb3cf1724e38b7f88a9ce85a4842/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40ef37eb3cf1724e38b7f88a9ce85a4842",
+        "session": "6ad0a24d8303f49d14409a669d430b6f",
+        "user_id": 3,
+        "username": "edx"
+    },
+    "data": {
+        "answers": {
+            "3fc5461f86764ad7bdbdf6cbdde61e66_2_1": [
+                "choice_0",
+                "choice_2"
+            ]
+        },
+        "attempts": 10,
+        "correct_map": {
+            "3fc5461f86764ad7bdbdf6cbdde61e66_2_1": {
+                "answervariable": null,
+                "correctness": "incorrect",
+                "hint": "",
+                "hintmode": null,
+                "msg": "",
+                "npoints": null,
+                "queuestate": null
+            }
+        },
+        "grade": 0,
+        "max_grade": 0,
+        "problem_id": "block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66",
+        "state": {
+            "correct_map": {
+                "3fc5461f86764ad7bdbdf6cbdde61e66_2_1": {
+                    "answervariable": null,
+                    "correctness": "incorrect",
+                    "hint": "",
+                    "hintmode": null,
+                    "msg": "",
+                    "npoints": null,
+                    "queuestate": null
+                }
+            },
+            "done": true,
+            "has_saved_answers": false,
+            "input_state": {
+                "3fc5461f86764ad7bdbdf6cbdde61e66_2_1": {}
+            },
+            "seed": 1,
+            "student_answers": {
+                "3fc5461f86764ad7bdbdf6cbdde61e66_2_1": [
+                    "choice_0",
+                    "choice_1",
+                    "choice_2",
+                    "choice_3"
+                ]
+            }
+        },
+        "submission": {
+            "3fc5461f86764ad7bdbdf6cbdde61e66_2_1": {
+                "answer": [
+                    "a correct answer",
+                    "an incorrect answer"
+                ],
+                "correct": false,
+                "group_label": "",
+                "input_type": "checkboxgroup",
+                "question": "Add the question text, or prompt, here. This text is required.",
+                "response_type": "choiceresponse",
+                "variant": ""
+            }
+        },
+        "success": "incorrect"
+    },
+    "name": "problem_check",
+    "timestamp": "2020-07-14T14:39:26.906232+00:00"
+}

--- a/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
@@ -151,13 +151,17 @@ class ProblemSubmittedTransformer(BaseProblemsTransformer):
             `Result`
         """
         event_data = self.get_data('data')
+        if event_data['weighted_possible'] > 0:
+            scaled = event_data['weighted_earned']/event_data['weighted_possible']
+        else:
+            scaled = 0
         return Result(
             success=event_data['weighted_earned'] >= event_data['weighted_possible'],
             score={
                 'min': 0,
                 'max': event_data['weighted_possible'],
                 'raw': event_data['weighted_earned'],
-                'scaled': event_data['weighted_earned']/event_data['weighted_possible']
+                'scaled': scaled
             }
         )
 
@@ -261,14 +265,23 @@ class ProblemCheckTransformer(BaseProblemsTransformer):
         else:
             response = event_data.get('answers', None)
 
+        max_grade = event_data.get('max_grade', None)
+        grade = event_data.get('grade', None)
+        scaled = None
+
+        if max_grade is not None and grade is not None:
+            if max_grade > 0:
+                scaled = grade / max_grade
+            else:
+                scaled = 0
+
         return Result(
             success=event_data.get('success', None) == 'correct',
             score={
                 'min': 0,
-                'max': event_data.get('max_grade', None),
-                'raw': event_data.get('grade', None),
-                'scaled': event_data.get('grade', None) / event_data.get('max_grade', None)
-                if event_data.get('max_grade', None) is not None and event_data.get('grade', None) is not None else None
+                'max': max_grade,
+                'raw': grade,
+                'scaled': scaled,
             },
             response=response
         )

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.weighted_possible_0.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.weighted_possible_0.json
@@ -1,0 +1,51 @@
+{
+    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "actor": {
+        "objectType": "Agent",
+        "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}
+    },
+    "context": {
+        "contextActivities": {
+            "parent": [
+                {
+                    "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+                    "objectType": "Activity",
+                    "definition": {
+                      "name": {
+                        "en-US": "Demonstration Course"
+                      },
+                      "type": "http://adlnet.gov/expapi/activities/course"
+                    }
+                }
+            ]
+        },
+        "extensions": {
+            "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+            "https://w3id.org/xapi/openedx/extensions/session-id": "993110e9c27848a545da74a74114158d"
+        }
+    },
+    "object": {
+        "definition": {
+            "type": "http://adlnet.gov/expapi/activities/question"
+        },
+        "id": "http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66",
+        "objectType": "Activity"
+    },
+    "result": {
+        "score": {
+            "max": 0.0,
+            "min": 0.0,
+            "raw": 0.0,
+            "scaled": 0.0
+        },
+        "success": true
+    },
+    "timestamp": "2020-07-15T05:59:29.700909+00:00",
+    "verb": {
+        "display": {
+            "en": "attempted"
+        },
+        "id": "http://adlnet.gov/expapi/verbs/attempted"
+    },
+    "version": "1.0.3"
+}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).max_grade_0.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).max_grade_0.json
@@ -1,0 +1,59 @@
+{
+    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "actor": {
+        "objectType": "Agent",
+        "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}
+    },
+    "context": {
+        "contextActivities": {
+            "parent": [
+                {
+                    "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+                    "objectType": "Activity",
+                    "definition": {
+                      "name": {
+                        "en-US": "Demonstration Course"
+                      },
+                      "type": "http://adlnet.gov/expapi/activities/course"
+                    }
+                }
+            ]
+        },
+        "extensions": {
+            "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+            "https://w3id.org/xapi/openedx/extensions/session-id": "6ad0a24d8303f49d14409a669d430b6f"
+        }
+    },
+    "object": {
+        "definition": {
+            "extensions":{
+              "http://id.tincanapi.com/extension/attempt-id": 10
+            },
+            "description": {
+              "en-US": "Add the question text, or prompt, here. This text is required."
+            },
+            "interactionType": "choice",
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction"
+        },
+        "id": "http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66",
+        "objectType": "Activity"
+    },
+    "result": {
+        "response": "['a correct answer', 'an incorrect answer']",
+        "score": {
+            "max": 0,
+            "min": 0,
+            "raw": 0,
+            "scaled": 0
+        },
+        "success": false
+    },
+    "timestamp": "2020-07-14T14:39:26.906232+00:00",
+    "verb": {
+        "display": {
+            "en": "evaluated"
+        },
+        "id": "https://w3id.org/xapi/acrossx/verbs/evaluated"
+    },
+    "version": "1.0.3"
+}


### PR DESCRIPTION
**Description:** Some fields in the wild have unexpected 0 values, leading to "divide by 0" errors on transform. This PR handles them somewhat more elegantly.

Closes: #311 