### PR TITLE
fix: ignore statement without object id

### DIFF
--- a/event_routing_backends/utils/xapi_lrs_client.py
+++ b/event_routing_backends/utils/xapi_lrs_client.py
@@ -72,7 +72,13 @@ class LrsClient:
         """
         logger.debug('Sending {} xAPI statements to {}'.format(len(statement_data), self.URL))
 
-        response = self.lrs_client.save_statements(statement_data)
+        valid_statement_data = [statement for statement in statement_data if "id" in statement["object"]]
+
+        invalid_statement_data = [statement for statement in statement_data if "id" not in statement["object"]]
+
+        logger.debug(f"Invalid statements: {invalid_statement_data}")
+
+        response = self.lrs_client.save_statements(valid_statement_data)
 
         if not response.success:
             if response.response.code == 409:


### PR DESCRIPTION
**Description:** Do not try to send events without an **object.id**

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
