### PR TITLE
Emit multiple xAPI events for a multi-question submission

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,7 @@ omit =
     *admin.py
     *static*
     *templates*
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '5.5.5'
+__version__ = '5.6.0'

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '5.6.0'
+__version__ = '6.0.0'

--- a/event_routing_backends/backends/tests/test_events_router.py
+++ b/event_routing_backends/backends/tests/test_events_router.py
@@ -153,9 +153,9 @@ class TestEventsRouter(TestCase):
     @patch('event_routing_backends.models.RouterConfiguration.get_enabled_routers')
     def test_with_processor_exception(self, mocked_get_enabled_routers, mocked_logger, mocked_post):
         processors = [
-            MagicMock(return_value=self.transformed_event),
-            MagicMock(side_effect=EventEmissionExit, return_value=self.transformed_event),
-            MagicMock(return_value=self.transformed_event),
+            MagicMock(return_value=[self.transformed_event]),
+            MagicMock(side_effect=EventEmissionExit, return_value=[self.transformed_event]),
+            MagicMock(return_value=[self.transformed_event]),
         ]
         processors[1].side_effect = EventEmissionExit
 
@@ -164,8 +164,8 @@ class TestEventsRouter(TestCase):
         router = EventsRouter(processors=processors, backend_name='test')
         router.send(self.transformed_event)
 
-        processors[0].assert_called_once_with(self.transformed_event)
-        processors[1].assert_called_once_with(self.transformed_event)
+        processors[0].assert_called_once_with([self.transformed_event])
+        processors[1].assert_called_once_with([self.transformed_event])
         processors[2].assert_not_called()
 
         mocked_post.assert_not_called()

--- a/event_routing_backends/backends/tests/test_events_router.py
+++ b/event_routing_backends/backends/tests/test_events_router.py
@@ -642,7 +642,14 @@ class TestEventsRouter(TestCase):
             mocked_logger.info.mock_calls
         )
 
-    def test_unsuccessful_routing_of_event_http(self):
+    @patch('event_routing_backends.utils.http_client.requests.post')
+    def test_unsuccessful_routing_of_event_http(self, mocked_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.request.method = "POST"
+        mock_response.text = "Fake Server Error"
+        mocked_post.return_value = mock_response
+
         host_configurations = {
                         'url': 'http://test4.com',
                         'auth_scheme': 'bearer',

--- a/event_routing_backends/processors/caliper/envelope_processor.py
+++ b/event_routing_backends/processors/caliper/envelope_processor.py
@@ -19,19 +19,22 @@ class CaliperEnvelopeProcessor:
         """
         self.sensor_id = sensor_id
 
-    def __call__(self, event):
+    def __call__(self, events):
         """
-        Envelope the caliper transformed event.
+        Envelope the caliper transformed events.
 
         Arguments:
-            event (dict):   IMS Caliper compliant event dict
+            events (list of dicts):   List of IMS Caliper compliant event dicts
 
         Returns:
-            dict
+            list of dicts
         """
-        return {
-            'sensor': self.sensor_id,
-            'sendTime': convert_datetime_to_iso(datetime.now(UTC)),
-            'data': [event],
-            'dataVersion': CALIPER_EVENT_CONTEXT
-        }
+        enveloped_events = []
+        for event in events:
+            enveloped_events.append({
+                'sensor': self.sensor_id,
+                'sendTime': convert_datetime_to_iso(datetime.now(UTC)),
+                'data': [event],
+                'dataVersion': CALIPER_EVENT_CONTEXT
+            })
+        return enveloped_events

--- a/event_routing_backends/processors/caliper/event_transformers/enrollment_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/enrollment_events.py
@@ -50,10 +50,11 @@ class EnrollmentEventTransformers(CaliperTransformer):
 
         # TODO: replace with anonymous enrollment id?
         course_root_url = self.get_object_iri('course', self.get_data('data.course_id', True))
-        caliper_object = {
+        caliper_object = super().get_object()
+        caliper_object.update({
             'id': course_root_url,
             'type': 'CourseOffering',
             'name': course['display_name'],
             'extensions': {'mode': self.get_data('data.mode')} if self.get_data('data.mode') is not None else None,
-        }
+        })
         return caliper_object

--- a/event_routing_backends/processors/caliper/event_transformers/navigation_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/navigation_events.py
@@ -39,7 +39,7 @@ class NavigationEventsTransformers(CaliperTransformer):
             dict
         """
         self.backend_name = 'caliper'
-        caliper_object = self.transformed_event['object']
+        caliper_object = super().get_object()
 
         data = self.get_data('data')
         extensions = {}

--- a/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
@@ -149,7 +149,7 @@ class ProblemEventsTransformers(CaliperTransformer):
         else:
             iri_url = object_id
 
-        caliper_object = self.transformed_event['object']
+        caliper_object = super().get_object()
         caliper_object.update({
             'id': self.get_object_iri('xblock', iri_url),
             'type': OBJECT_TYPE_MAP.get(key, 'Attempt'),

--- a/event_routing_backends/processors/caliper/event_transformers/video_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/video_events.py
@@ -82,7 +82,7 @@ class BaseVideoTransformer(CaliperTransformer):
             dict
         """
         self.backend_name = 'caliper'
-        caliper_object = self.transformed_event['object']
+        caliper_object = super().get_object()
         data = self.get_data('data')
         course_id = self.get_data('context.course_id', True)
         video_id = self.get_data('data.id', True)
@@ -176,10 +176,12 @@ class VideoSpeedChangedTransformer(BaseVideoTransformer):
     """
     Transform the event fired when a video's speed is changed.
     """
-    additional_fields = ('target', 'extensions',)
+    additional_fields = ('target',)
 
     def get_extensions(self):
-        return {
+        extensions = super().get_extensions()
+        extensions.update({
             'oldSpeed': self.get_data('old_speed'),
             'newSpeed': self.get_data('new_speed'),
-        }
+        })
+        return extensions

--- a/event_routing_backends/processors/caliper/tests/test_caliper.py
+++ b/event_routing_backends/processors/caliper/tests/test_caliper.py
@@ -35,7 +35,7 @@ class TestCaliperProcessor(SimpleTestCase):
     @patch('event_routing_backends.processors.mixins.base_transformer_processor.logger')
     def test_send_method_with_no_transformer_implemented(self, mocked_logger):
         with self.assertRaises(EventEmissionExit):
-            self.processor(self.sample_event)
+            self.processor([self.sample_event])
 
         mocked_logger.error.assert_called_once_with(
             'Could not get transformer for %s event.',
@@ -49,7 +49,7 @@ class TestCaliperProcessor(SimpleTestCase):
     @patch('event_routing_backends.processors.mixins.base_transformer_processor.logger')
     def test_send_method_with_unknown_exception(self, mocked_logger, _):
         with self.assertRaises(ValueError):
-            self.processor(self.sample_event)
+            self.processor([self.sample_event])
 
         mocked_logger.exception.assert_called_once_with(
             'There was an error while trying to transform event "sentinel.name" using CaliperProcessor'
@@ -66,14 +66,14 @@ class TestCaliperProcessor(SimpleTestCase):
         mocked_logger,
         mocked_get_transformer
     ):
-        transformed_event = {
+        transformed_event = [{
             'transformed_key': 'transformed_value'
-        }
+        }]
         mocked_transformer = MagicMock()
         mocked_transformer.transform.return_value = transformed_event
         mocked_get_transformer.return_value = mocked_transformer
 
-        self.processor(self.sample_event)
+        self.processor([self.sample_event])
 
         self.assertIn(
             call(
@@ -102,14 +102,14 @@ class TestCaliperProcessor(SimpleTestCase):
         mocked_logger,
         mocked_get_transformer
     ):
-        transformed_event = {
+        transformed_event = [{
             'transformed_key': 'transformed_value'
-        }
+        }]
         mocked_transformer = MagicMock()
         mocked_transformer.transform.return_value = transformed_event
         mocked_get_transformer.return_value = mocked_transformer
 
-        self.processor(self.sample_event)
+        self.processor([self.sample_event])
 
         self.assertIn(
             call(
@@ -131,5 +131,5 @@ class TestCaliperProcessor(SimpleTestCase):
         backend = CaliperProcessor()
         backend.registry = None
         with self.assertRaises(EventEmissionExit):
-            self.assertIsNone(backend(self.sample_event))
+            self.assertIsNone(backend([self.sample_event]))
         mocked_logger.exception.assert_called_once()

--- a/event_routing_backends/processors/caliper/tests/test_caliper.py
+++ b/event_routing_backends/processors/caliper/tests/test_caliper.py
@@ -66,9 +66,9 @@ class TestCaliperProcessor(SimpleTestCase):
         mocked_logger,
         mocked_get_transformer
     ):
-        transformed_event = [{
+        transformed_event = {
             'transformed_key': 'transformed_value'
-        }]
+        }
         mocked_transformer = MagicMock()
         mocked_transformer.transform.return_value = transformed_event
         mocked_get_transformer.return_value = mocked_transformer
@@ -102,9 +102,9 @@ class TestCaliperProcessor(SimpleTestCase):
         mocked_logger,
         mocked_get_transformer
     ):
-        transformed_event = [{
+        transformed_event = {
             'transformed_key': 'transformed_value'
-        }]
+        }
         mocked_transformer = MagicMock()
         mocked_transformer.transform.return_value = transformed_event
         mocked_get_transformer.return_value = mocked_transformer

--- a/event_routing_backends/processors/caliper/tests/test_envelope_processor.py
+++ b/event_routing_backends/processors/caliper/tests/test_envelope_processor.py
@@ -30,10 +30,10 @@ class TestCaliperEnvelopeProcessor(TestCase):
     def test_caliper_envelope_processor(self, mocked_datetime):
         mocked_datetime.now.return_value = FROZEN_TIME
 
-        result = CaliperEnvelopeProcessor(sensor_id=self.sensor_id)(self.sample_event)
-        self.assertEqual(result, {
+        result = CaliperEnvelopeProcessor(sensor_id=self.sensor_id)([self.sample_event])
+        self.assertEqual(result, [{
             'sensor': self.sensor_id,
             'sendTime': convert_datetime_to_iso(str(FROZEN_TIME)),
             'data': [self.sample_event],
             'dataVersion': CALIPER_EVENT_CONTEXT
-        })
+        }])

--- a/event_routing_backends/processors/mixins/base_transformer_processor.py
+++ b/event_routing_backends/processors/mixins/base_transformer_processor.py
@@ -18,33 +18,37 @@ class BaseTransformerProcessorMixin:
 
     registry = None
 
-    def __call__(self, event):
+    def __call__(self, events):
         """
-        Transform and then route the event to the configured routers.
+        Transform the given events, and return the transformed events.
 
         Arguments:
-            event (dict):   Event to be transformed and delivered.
+            event (list of dicts):   Events to be transformed.
 
         Returns:
-            transformed event (dict)
+            transformed events (list of ANY)
 
         Raises:
             EventEmissionExit except.on:  if no transformer is registered for an event.
             ANY exception: if raised.
         """
-        transformed_event = self.transform_event(event)
-
-        if transformed_event:
-            return transformed_event
-
-        raise EventEmissionExit
+        returned_events = []
+        for event in events:
+            transformed_event = self.transform_event(event)
+            if not transformed_event:
+                raise EventEmissionExit
+            if isinstance(transformed_event, list):
+                returned_events += transformed_event
+            else:
+                returned_events.append(transformed_event)
+        return returned_events
 
     def transform_event(self, event):
         """
         Transform the event.
 
-        Transformer method can return transformed event in any data structure format
-        (dict or any custom class) but the configured router(s) MUST support it.
+        Transformer method can return transformed events in any data structure format
+        (dict, list, or any custom class) but the configured router(s) MUST support it.
 
         Arguments:
             event (dict):   Event to be transformed.

--- a/event_routing_backends/processors/tests/fixtures/current/problem_check(server,multiple_questions,correct).json
+++ b/event_routing_backends/processors/tests/fixtures/current/problem_check(server,multiple_questions,correct).json
@@ -1,0 +1,160 @@
+{
+   "name":"problem_check",
+   "context":{
+      "course_id":"course-v1:edX+DemoX+Demo_Course",
+      "course_user_tags":{
+         
+      },
+      "user_id":8,
+      "path":"/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4/handler/xmodule_handler/problem_check",
+      "org_id":"edX",
+      "enterprise_uuid":"",
+      "module":{
+         "display_name":"Multiple Choice Questions",
+         "usage_key":"block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4"
+      },
+      "asides":{
+         
+      }
+   },
+   "username":"staff",
+   "session":"97662bef7c463c187b8fd91e0f580468",
+   "ip":"172.18.0.1",
+   "agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0",
+   "host":"localhost:18000",
+   "referer":"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@vertical+block@54bb9b142c6c4c22afc62bcb628f0e68?exam_access=&format=Homework&recheck_access=1&show_bookmark=0&show_title=0&view=student_view",
+   "accept_language":"en-US,en;q=0.5",
+   "event":{
+      "state":{
+         "seed":1,
+         "student_answers":{
+            "a0effb954cca4759994f1ac9e9434bf4_2_1":"blue",
+            "a0effb954cca4759994f1ac9e9434bf4_4_1":[
+               "choice_0",
+               "choice_2"
+            ],
+            "a0effb954cca4759994f1ac9e9434bf4_3_1":"choice_3"
+         },
+         "has_saved_answers":false,
+         "correct_map":{
+            "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+               "correctness":"correct",
+               "npoints":null,
+               "msg":"",
+               "hint":"",
+               "hintmode":null,
+               "queuestate":null,
+               "answervariable":null
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+               "correctness":"incorrect",
+               "npoints":null,
+               "msg":"",
+               "hint":"",
+               "hintmode":null,
+               "queuestate":null,
+               "answervariable":null
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+               "correctness":"correct",
+               "npoints":null,
+               "msg":"",
+               "hint":"",
+               "hintmode":null,
+               "queuestate":null,
+               "answervariable":null
+            }
+         },
+         "input_state":{
+            "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+               
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+               
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+               
+            }
+         },
+         "done":true
+      },
+      "problem_id":"block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+      "answers":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":"blue",
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":[
+            "choice_0",
+            "choice_2"
+         ],
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":"choice_2"
+      },
+      "grade":3,
+      "max_grade":3,
+      "correct_map":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+            "correctness":"correct",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+            "correctness":"correct",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+            "correctness":"correct",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         }
+      },
+      "success":"correct",
+      "attempts":3,
+      "submission":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+            "question":"What color is the open ocean on a sunny day?",
+            "answer":"blue",
+            "response_type":"optionresponse",
+            "input_type":"optioninput",
+            "correct":true,
+            "variant":"",
+            "group_label":""
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+            "question":"Which of the following are musical instruments?",
+            "answer":[
+               "a piano",
+               "a guitar"
+            ],
+            "response_type":"choiceresponse",
+            "input_type":"checkboxgroup",
+            "correct":true,
+            "variant":"",
+            "group_label":""
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+            "question":"Which piece of furniture is built for sitting?",
+            "answer":"a chair",
+            "response_type":"multiplechoiceresponse",
+            "input_type":"choicegroup",
+            "correct":true,
+            "variant":"",
+            "group_label":""
+         }
+      }
+   },
+   "time":"2023-08-03T06:32:31.431355+00:00",
+   "event_type":"problem_check",
+   "event_source":"server",
+   "page":"x_module"
+}

--- a/event_routing_backends/processors/tests/fixtures/current/problem_check(server,multiple_questions,incorrect).json
+++ b/event_routing_backends/processors/tests/fixtures/current/problem_check(server,multiple_questions,incorrect).json
@@ -1,0 +1,127 @@
+{
+   "name":"problem_check",
+   "context":{
+      "course_id":"course-v1:edX+DemoX+Demo_Course",
+      "course_user_tags":{
+         
+      },
+      "user_id":8,
+      "path":"/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4/handler/xmodule_handler/problem_check",
+      "org_id":"edX",
+      "enterprise_uuid":"",
+      "module":{
+         "display_name":"Multiple Choice Questions",
+         "usage_key":"block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4"
+      },
+      "asides":{
+         
+      }
+   },
+   "username":"staff",
+   "session":"97662bef7c463c187b8fd91e0f580468",
+   "ip":"172.18.0.1",
+   "agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0",
+   "host":"localhost:18000",
+   "referer":"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@vertical+block@54bb9b142c6c4c22afc62bcb628f0e68?exam_access=&format=Homework&recheck_access=1&show_bookmark=0&show_title=0&view=student_view",
+   "accept_language":"en-US,en;q=0.5",
+   "event":{
+      "state":{
+         "seed":1,
+         "student_answers":{
+            
+         },
+         "has_saved_answers":false,
+         "correct_map":{
+            
+         },
+         "input_state":{
+            "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+               
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+               
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+               
+            }
+         },
+         "done":false
+      },
+      "problem_id":"block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+      "answers":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":"yellow",
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":[
+            "choice_3"
+         ],
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":"choice_3"
+      },
+      "grade":0,
+      "max_grade":3,
+      "correct_map":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+            "correctness":"incorrect",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+            "correctness":"incorrect",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+            "correctness":"incorrect",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         }
+      },
+      "success":"incorrect",
+      "attempts":1,
+      "submission":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+            "question":"What color is the open ocean on a sunny day?",
+            "answer":"yellow",
+            "response_type":"optionresponse",
+            "input_type":"optioninput",
+            "correct":false,
+            "variant":"",
+            "group_label":""
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+            "question":"Which of the following are musical instruments?",
+            "answer":[
+               "a window"
+            ],
+            "response_type":"choiceresponse",
+            "input_type":"checkboxgroup",
+            "correct":false,
+            "variant":"",
+            "group_label":""
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+            "question":"Which piece of furniture is built for sitting?",
+            "answer":"a bookshelf",
+            "response_type":"multiplechoiceresponse",
+            "input_type":"choicegroup",
+            "correct":false,
+            "variant":"",
+            "group_label":""
+         }
+      }
+   },
+   "time":"2023-08-03T06:30:32.026903+00:00",
+   "event_type":"problem_check",
+   "event_source":"server",
+   "page":"x_module"
+}

--- a/event_routing_backends/processors/tests/fixtures/current/problem_check(server,multiple_questions,partial_correct).json
+++ b/event_routing_backends/processors/tests/fixtures/current/problem_check(server,multiple_questions,partial_correct).json
@@ -1,0 +1,159 @@
+{
+   "name":"problem_check",
+   "context":{
+      "course_id":"course-v1:edX+DemoX+Demo_Course",
+      "course_user_tags":{
+         
+      },
+      "user_id":8,
+      "path":"/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4/handler/xmodule_handler/problem_check",
+      "org_id":"edX",
+      "enterprise_uuid":"",
+      "module":{
+         "display_name":"Multiple Choice Questions",
+         "usage_key":"block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4"
+      },
+      "asides":{
+         
+      }
+   },
+   "username":"staff",
+   "session":"2c65c4e9e6a637feb42426fd35b5dac3",
+   "ip":"172.18.0.1",
+   "agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0",
+   "host":"localhost:18000",
+   "referer":"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@vertical+block@54bb9b142c6c4c22afc62bcb628f0e68?exam_access=&format=Homework&recheck_access=1&show_bookmark=0&show_title=0&view=student_view",
+   "accept_language":"en-US,en;q=0.5",
+   "event":{
+      "state":{
+         "seed":1,
+         "student_answers":{
+            "a0effb954cca4759994f1ac9e9434bf4_2_1":"yellow",
+            "a0effb954cca4759994f1ac9e9434bf4_4_1":[
+               "choice_3"
+            ],
+            "a0effb954cca4759994f1ac9e9434bf4_3_1":"choice_3"
+         },
+         "has_saved_answers":false,
+         "correct_map":{
+            "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+               "correctness":"incorrect",
+               "npoints":null,
+               "msg":"",
+               "hint":"",
+               "hintmode":null,
+               "queuestate":null,
+               "answervariable":null
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+               "correctness":"incorrect",
+               "npoints":null,
+               "msg":"",
+               "hint":"",
+               "hintmode":null,
+               "queuestate":null,
+               "answervariable":null
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+               "correctness":"incorrect",
+               "npoints":null,
+               "msg":"",
+               "hint":"",
+               "hintmode":null,
+               "queuestate":null,
+               "answervariable":null
+            }
+         },
+         "input_state":{
+            "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+               
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+               
+            },
+            "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+               
+            }
+         },
+         "done":true
+      },
+      "problem_id":"block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+      "answers":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":"blue",
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":[
+            "choice_0",
+            "choice_2"
+         ],
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":"choice_3"
+      },
+      "grade":2,
+      "max_grade":3,
+      "correct_map":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+            "correctness":"correct",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+            "correctness":"incorrect",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+            "correctness":"correct",
+            "npoints":null,
+            "msg":"",
+            "hint":"",
+            "hintmode":null,
+            "queuestate":null,
+            "answervariable":null
+         }
+      },
+      "success":"incorrect",
+      "attempts":2,
+      "submission":{
+         "a0effb954cca4759994f1ac9e9434bf4_2_1":{
+            "question":"What color is the open ocean on a sunny day?",
+            "answer":"blue",
+            "response_type":"optionresponse",
+            "input_type":"optioninput",
+            "correct":true,
+            "variant":"",
+            "group_label":""
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_4_1":{
+            "question":"Which of the following are musical instruments?",
+            "answer":[
+               "a piano",
+               "a guitar"
+            ],
+            "response_type":"choiceresponse",
+            "input_type":"checkboxgroup",
+            "correct":true,
+            "variant":"",
+            "group_label":""
+         },
+         "a0effb954cca4759994f1ac9e9434bf4_3_1":{
+            "question":"Which piece of furniture is built for sitting?",
+            "answer":"a bookshelf",
+            "response_type":"multiplechoiceresponse",
+            "input_type":"choicegroup",
+            "correct":false,
+            "variant":"",
+            "group_label":""
+         }
+      }
+   },
+   "time":"2023-08-03T06:31:39.005451+00:00",
+   "event_type":"problem_check",
+   "event_source":"server",
+   "page":"x_module"
+}

--- a/event_routing_backends/processors/tests/transformers_test_mixin.py
+++ b/event_routing_backends/processors/tests/transformers_test_mixin.py
@@ -5,6 +5,7 @@ import json
 import os
 from abc import abstractmethod
 from unittest.mock import patch
+from uuid import UUID
 
 import ddt
 from django.contrib.auth import get_user_model
@@ -89,11 +90,12 @@ class TransformersTestMixin:
         Every transformer's test case will implement its own logic to test
         events transformation
         """
-    @patch('event_routing_backends.helpers.uuid')
+    @patch('event_routing_backends.helpers.uuid.uuid4')
     @ddt.data(*EVENT_FIXTURE_FILENAMES)
-    def test_event_transformer(self, event_filename, mocked_uuid):
-        mocked_uuid.uuid4.return_value = '32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb'
-        mocked_uuid.uuid5.return_value = '32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb'
+    def test_event_transformer(self, event_filename, mocked_uuid4):
+        # Used to generate the anonymized actor.name,
+        # which in turn is used to generate the event UUID.
+        mocked_uuid4.return_value = UUID('32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb')
 
         # if an event's expected fixture doesn't exist, the test shouldn't fail.
         # evaluate transformation of only supported event fixtures.

--- a/event_routing_backends/processors/xapi/statements.py
+++ b/event_routing_backends/processors/xapi/statements.py
@@ -1,0 +1,15 @@
+"""
+xAPI statement classes
+"""
+from tincan import Activity
+
+
+class GroupActivity(Activity):
+    """
+    Subclass of tincan.Activity which reports object_type="GroupActivity"
+
+    For use with Activites that contain one or more child Activities, like Problems that contain multiple Questions.
+    """
+    @Activity.object_type.setter
+    def object_type(self, _):
+        self._object_type = 'GroupActivity'

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/complete_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/complete_video.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "f7c8b743-f18f-5016-8455-35ff8a2f8020",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "bb946682-b0b9-5dc2-a17c-605ef5833c98",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "bb946682-b0b9-5dc2-a17c-605ef5833c98",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "bb946682-b0b9-5dc2-a17c-605ef5833c98",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.deactivated.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.deactivated.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "074afb4a-90d6-57d6-8a6a-4867b4bfcc5f",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.mode_changed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.mode_changed.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "bb946682-b0b9-5dc2-a17c-605ef5833c98",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.grade.now_failed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.grade.now_failed.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "ecf2a41b-d1c8-50f7-bd6f-79b305159dae",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.grade.now_passed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.grade.now_passed.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "ebfef69f-dd05-5bf0-bf90-bad645bc6992",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.grade.passed.first_time.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.grade.passed.first_time.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "ebfef69f-dd05-5bf0-bf90-bad645bc6992",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.created.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.created.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "b57c965a-218a-5a17-aee8-9f3dc75c5bb3",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.deleted.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.deleted.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "54acd352-b4f5-56fb-a328-d7fa43d90710",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.edited.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.edited.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "196cf44f-9d76-5d76-ac0d-683359d9b88b",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.reported.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.reported.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "b52e9a1c-3ff6-5841-8cb3-d9edbed4fc4f",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.unreported.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.unreported.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "23ae2117-975a-5669-9d1d-cc47928b1959",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.voted.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.response.voted.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "806c7c48-7df6-56b9-bdb0-c379a968acf5",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.created.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.created.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "a4e3d431-0281-5b3e-bcf7-0ddbeb8543b2",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.deleted.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.deleted.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "e57ea5a8-ad20-5717-b648-824bede138aa",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.edited.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.edited.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "ae1a9bfe-2d3b-5afd-87f4-ad8d4c596932",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.reported.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.reported.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "81c7f03f-e07e-5b54-9095-f5019e5bbef3",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.unreported.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.unreported.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "0ce637d7-e823-5447-8cdf-8da3afb4fd9b",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.viewed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.viewed.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "d1325940-fe1b-5042-90c1-e3365960c9a1",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.voted.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.forum.thread.voted.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "883a9580-f6bc-55b6-b5c8-1d5a13a8bdd7",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "a10da8af-8e6a-5d1c-b7d5-cdabaacc0ba8",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.weighted_possible_0.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.weighted_possible_0.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "a10da8af-8e6a-5d1c-b7d5-cdabaacc0ba8",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.completed(proposed).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.completed(proposed).json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "1940cdf9-6a89-5cb7-82f9-5b0955584db8",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "e9b9ba0f-d976-5656-9a6c-d432b12335ea",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "01b620b3-0cba-556e-96d5-d1e9ef63489d",
     "actor": {
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"},
         "objectType": "Agent"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "01b620b3-0cba-556e-96d5-d1e9ef63489d",
     "actor": {
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"},
         "objectType": "Agent"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "01b620b3-0cba-556e-96d5-d1e9ef63489d",
     "actor": {
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"},
         "objectType": "Agent"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.outline.selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.outline.selected.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "d30c30af-2eeb-5ae3-a765-4e2ca9bb3283",
     "actor": {
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"},
         "objectType": "Agent"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "2802561d-3e8e-56d4-8944-07a8fbfd02b2",
     "actor": {
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"},
         "objectType": "Agent"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "6e0efdce-2611-52f8-a213-dcd81b78cfbd",
     "actor": {
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"},
         "objectType": "Agent"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "0f73de3b-445e-5674-aab9-b0117c64671a",
     "actor": {
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"},
         "objectType": "Agent"

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.video.closed_captions.hidden.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.video.closed_captions.hidden.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "9e08cf47-e86f-5b64-b48f-a4d524f9a7e4",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.video.closed_captions.shown.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.video.closed_captions.shown.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "9e08cf47-e86f-5b64-b48f-a4d524f9a7e4",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/hide_transcript.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/hide_transcript.json
@@ -1,5 +1,5 @@
 {
-    "id": "0b9e39477cf34507a7a48f74be381fdd",
+    "id": "8c936f51-267d-51ad-a850-9fffdb7595de",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "3feca024-a2a2-5ee3-9307-50711dc48abd",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.required.only.data.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "3feca024-a2a2-5ee3-9307-50711dc48abd",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/pause_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/pause_video.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "b2fff5f6-c77d-5aa4-a08b-bb547d6ee5a6",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "203e182c-6a2d-5458-9c61-a271297d459a",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
@@ -26,6 +26,7 @@
     },
     "object": {
         "definition": {
+            "interactionType": "other",
             "type": "http://adlnet.gov/expapi/activities/cmi.interaction"
         },
         "id": "http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66",

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "2a1f0f7c-6636-52df-913b-59e2f197a58e",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).required.only.data.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "37e0953c-fa85-5435-8c53-723909ab81d9",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser)legacy.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser)legacy.json
@@ -26,6 +26,7 @@
     },
     "object": {
         "definition": {
+            "interactionType": "other",
             "type": "http://adlnet.gov/expapi/activities/cmi.interaction"
         },
         "id": "http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@sequential+block@ef37eb3cf1724e38b7f88a9ce85a4842",

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser)legacy.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser)legacy.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "2a1f0f7c-6636-52df-913b-59e2f197a58e",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "c9c7da1a-0cf0-5161-9bf5-35c61091f826",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).max_grade_0.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).max_grade_0.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "c9c7da1a-0cf0-5161-9bf5-35c61091f826",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server)_no_response_type.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server)_no_response_type.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "c9c7da1a-0cf0-5161-9bf5-35c61091f826",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server)_no_response_type.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server)_no_response_type.json
@@ -29,6 +29,7 @@
             "extensions":{
               "http://id.tincanapi.com/extension/attempt-id": 10
             },
+            "name": {"en-US": "Checkboxes"},
             "interactionType": "other",
             "type": "http://adlnet.gov/expapi/activities/cmi.interaction"
         },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
@@ -1,6 +1,7 @@
+[
 {
   "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
-  "result": {"score": {"min": 0.0}, "success": false},
+  "result": {"score": {"min": 0, "max": 3, "raw": 3, "scaled": 1}, "success": true},
   "version": "1.0.3",
   "actor": {
     "objectType": "Agent",
@@ -16,10 +17,12 @@
     }
   },
   "object": {
-    "objectType": "Activity",
+    "objectType": "GroupActivity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
     "definition": {
       "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
-      "interactionType": "choice"
+      "name": {"en-US": "Multiple Choice Questions"},
+      "interactionType": "other"
     }
   },
   "context": {
@@ -42,4 +45,203 @@
       "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
     }
   }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "blue", "success": true},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_2_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "What color is the open ocean on a sunny day?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "['a piano', 'a guitar']", "success": true},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_4_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "Which of the following are musical instruments?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "a chair", "success": true},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_3_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "Which piece of furniture is built for sitting?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
 }
+]

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
@@ -47,7 +47,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "2cb89608-ab9c-5129-ae6e-4d7d2f9cde68",
   "result": {"response": "blue", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -113,7 +113,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "d0b94156-376d-5012-be91-c6235d3a0770",
   "result": {"response": "['a piano', 'a guitar']", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -179,7 +179,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "a51f4090-8ebf-5644-a669-a18768523eab",
   "result": {"response": "a chair", "success": true},
   "version": "1.0.3",
   "actor": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
@@ -1,6 +1,6 @@
 [
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"score": {"min": 0, "max": 3, "raw": 3, "scaled": 1}, "success": true},
   "version": "1.0.3",
   "actor": {
@@ -47,7 +47,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "blue", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -76,7 +76,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {
@@ -113,7 +113,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "['a piano', 'a guitar']", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -142,7 +142,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {
@@ -179,7 +179,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "a chair", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -208,7 +208,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,correct).json
@@ -1,0 +1,45 @@
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"score": {"min": 0.0}, "success": false},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "contextActivities": {
+      "parent": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
+}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
@@ -1,6 +1,6 @@
 [
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"score": {"min": 0, "max": 3, "raw": 0, "scaled": 0}, "success": false},
   "version": "1.0.3",
   "actor": {
@@ -49,7 +49,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "yellow", "success": false},
   "version": "1.0.3",
   "actor": {
@@ -78,7 +78,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {
@@ -115,7 +115,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "['a window']", "success": false},
   "version": "1.0.3",
   "actor": {
@@ -144,7 +144,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {
@@ -181,7 +181,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "a bookshelf", "success": false},
   "version": "1.0.3",
   "actor": {
@@ -210,7 +210,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
@@ -1,6 +1,7 @@
+[
 {
   "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
-  "result": {"score": {"min": 0.0}, "success": false},
+  "result": {"score": {"min": 0, "max": 3, "raw": 0, "scaled": 0}, "success": false},
   "version": "1.0.3",
   "actor": {
     "objectType": "Agent",
@@ -16,10 +17,14 @@
     }
   },
   "object": {
-    "objectType": "Activity",
+    "objectType": "GroupActivity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
     "definition": {
       "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
-      "interactionType": "choice"
+      "name": {
+        "en-US": "Multiple Choice Questions"
+      },
+      "interactionType": "other"
     }
   },
   "context": {
@@ -42,4 +47,203 @@
       "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
     }
   }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "yellow", "success": false},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_2_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "What color is the open ocean on a sunny day?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "['a window']", "success": false},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_4_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "Which of the following are musical instruments?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "a bookshelf", "success": false},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_3_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "Which piece of furniture is built for sitting?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
 }
+]

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
@@ -49,7 +49,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "2cb89608-ab9c-5129-ae6e-4d7d2f9cde68",
   "result": {"response": "yellow", "success": false},
   "version": "1.0.3",
   "actor": {
@@ -115,7 +115,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "d0b94156-376d-5012-be91-c6235d3a0770",
   "result": {"response": "['a window']", "success": false},
   "version": "1.0.3",
   "actor": {
@@ -181,7 +181,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "a51f4090-8ebf-5644-a669-a18768523eab",
   "result": {"response": "a bookshelf", "success": false},
   "version": "1.0.3",
   "actor": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,incorrect).json
@@ -1,0 +1,45 @@
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"score": {"min": 0.0}, "success": false},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "contextActivities": {
+      "parent": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "97662bef7c463c187b8fd91e0f580468"
+    }
+  }
+}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
@@ -1,0 +1,45 @@
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"score": {"min": 0.0}, "success": false},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "contextActivities": {
+      "parent": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "2c65c4e9e6a637feb42426fd35b5dac3"
+    }
+  }
+}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
@@ -47,7 +47,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "2cb89608-ab9c-5129-ae6e-4d7d2f9cde68",
   "result": {"response": "blue", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -113,7 +113,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "d0b94156-376d-5012-be91-c6235d3a0770",
   "result": {"response": "['a piano', 'a guitar']", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -179,7 +179,7 @@
   }
 },
 {
-  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
+  "id": "a51f4090-8ebf-5644-a669-a18768523eab",
   "result": {"response": "a bookshelf", "success": false},
   "version": "1.0.3",
   "actor": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
@@ -1,6 +1,6 @@
 [
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"score": {"min": 0, "max": 3, "raw": 2, "scaled": 0.6666666666666666}, "success": false},
   "version": "1.0.3",
   "actor": {
@@ -47,7 +47,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "blue", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -76,7 +76,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {
@@ -113,7 +113,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "['a piano', 'a guitar']", "success": true},
   "version": "1.0.3",
   "actor": {
@@ -142,7 +142,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {
@@ -179,7 +179,7 @@
   }
 },
 {
-  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
   "result": {"response": "a bookshelf", "success": false},
   "version": "1.0.3",
   "actor": {
@@ -208,7 +208,7 @@
   },
   "context": {
     "statement": {
-      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "id": "b2f56b44-07f9-5044-85d1-c1dbc550d35f",
       "objectType": "StatementRef"
     },
     "contextActivities": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,multiple_questions,partial_correct).json
@@ -1,6 +1,7 @@
+[
 {
   "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
-  "result": {"score": {"min": 0.0}, "success": false},
+  "result": {"score": {"min": 0, "max": 3, "raw": 2, "scaled": 0.6666666666666666}, "success": false},
   "version": "1.0.3",
   "actor": {
     "objectType": "Agent",
@@ -16,10 +17,12 @@
     }
   },
   "object": {
-    "objectType": "Activity",
+    "objectType": "GroupActivity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
     "definition": {
       "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
-      "interactionType": "choice"
+      "name": {"en-US": "Multiple Choice Questions"},
+      "interactionType": "other"
     }
   },
   "context": {
@@ -42,4 +45,203 @@
       "https://w3id.org/xapi/openedx/extensions/session-id": "2c65c4e9e6a637feb42426fd35b5dac3"
     }
   }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "blue", "success": true},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_2_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "What color is the open ocean on a sunny day?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "2c65c4e9e6a637feb42426fd35b5dac3"
+    }
+  }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "['a piano', 'a guitar']", "success": true},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_4_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "Which of the following are musical instruments?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "2c65c4e9e6a637feb42426fd35b5dac3"
+    }
+  }
+},
+{
+  "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+  "result": {"response": "a bookshelf", "success": false},
+  "version": "1.0.3",
+  "actor": {
+    "objectType": "Agent",
+    "account": {
+      "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "homePage": "http://localhost:18000"
+    }
+  },
+  "verb": {
+    "id": "https://w3id.org/xapi/acrossx/verbs/evaluated",
+    "display": {
+      "en": "evaluated"
+    }
+  },
+  "object": {
+    "objectType": "Activity",
+    "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4_3_1",
+    "definition": {
+      "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+      "description": {
+        "en-US": "Which piece of furniture is built for sitting?"
+      },
+      "interactionType": "choice"
+    }
+  },
+  "context": {
+    "statement": {
+      "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
+      "objectType": "StatementRef"
+    },
+    "contextActivities": {
+      "parent": [
+        {
+          "objectType": "GroupActivity",
+          "id" :"http://localhost:18000/xblock/block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4",
+          "definition": {
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction",
+            "name": {
+              "en-US": "Multiple Choice Questions"
+            },
+            "interactionType": "other"
+          }
+        }
+      ],
+      "grouping": [
+        {
+          "id": "http://localhost:18000/course/course-v1:edX+DemoX+Demo_Course",
+          "objectType": "Activity",
+          "definition": {
+            "name": {
+              "en-US": "Demonstration Course"
+            },
+            "type": "http://adlnet.gov/expapi/activities/course"
+          }
+        }
+      ]
+    },
+    "extensions": {
+      "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+      "https://w3id.org/xapi/openedx/extensions/session-id": "2c65c4e9e6a637feb42426fd35b5dac3"
+    }
+  }
 }
+]

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,string_anwers).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,string_anwers).json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "c9c7da1a-0cf0-5161-9bf5-35c61091f826",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,unsupported_responsetype).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,unsupported_responsetype).json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "c9c7da1a-0cf0-5161-9bf5-35c61091f826",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/seek_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/seek_video.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "50e46aad-346e-58da-ab55-e599abcd554c",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/show_transcript.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/show_transcript.json
@@ -1,5 +1,5 @@
 {
-    "id": "0b9e39477cf34507a7a48f74be381fdd",
+    "id": "8c936f51-267d-51ad-a850-9fffdb7595de",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/showanswer.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/showanswer.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "c552e1bc-2a30-555c-99e8-79d72413eaf7",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/speed_change_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/speed_change_video.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "2f31f095-ee62-54d8-bcab-8e764a45b47f",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/stop_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/stop_video.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "d079c151-11f1-5a91-8e49-9627a5c9832d",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/video_hide_cc_menu.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/video_hide_cc_menu.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "9e08cf47-e86f-5b64-b48f-a4d524f9a7e4",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/video_show_cc_menu.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/video_show_cc_menu.json
@@ -1,5 +1,5 @@
 {
-    "id": "6d1f033b-3f70-458c-b53a-e6bb63cbaef9",
+    "id": "9e08cf47-e86f-5b64-b48f-a4d524f9a7e4",
     "actor": {
         "objectType": "Agent",
         "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}

--- a/event_routing_backends/processors/xapi/tests/test_transformers.py
+++ b/event_routing_backends/processors/xapi/tests/test_transformers.py
@@ -32,6 +32,28 @@ class TestXApiTransformers(TransformersTestMixin, TestCase):
         Test that transformed_event and expected_event are identical.
 
         Arguments:
+            transformed_event (dict or list)
+            expected_event (dict or list)
+
+        Raises:
+            AssertionError:     Raised if the two events are not same.
+        """
+        # Compare lists of events
+        if isinstance(expected_event, list):
+            assert isinstance(transformed_event, list)
+            assert len(transformed_event) == len(expected_event)
+            for idx, e_event in enumerate(expected_event):
+                self._compare_events(transformed_event[idx], e_event)
+
+        # Compare single events
+        else:
+            self._compare_events(transformed_event, expected_event)
+
+    def _compare_events(self, transformed_event, expected_event):
+        """
+        Test that transformed_event and expected_event are identical.
+
+        Arguments:
             transformed_event (dict)
             expected_event (dict)
 

--- a/event_routing_backends/processors/xapi/tests/test_transformers.py
+++ b/event_routing_backends/processors/xapi/tests/test_transformers.py
@@ -60,11 +60,7 @@ class TestXApiTransformers(TransformersTestMixin, TestCase):
         Raises:
             AssertionError:     Raised if the two events are not same.
         """
-        # id is a randomly generated UUID therefore not comparing that
         transformed_event_json = json.loads(transformed_event.to_json())
-        self.assertIn('id', transformed_event_json)
-        expected_event.pop('id')
-        transformed_event_json.pop('id')
         self.assertDictEqual(expected_event, transformed_event_json)
 
     @override_settings(XAPI_AGENT_IFI_TYPE='mbox')

--- a/event_routing_backends/processors/xapi/tests/test_transformers.py
+++ b/event_routing_backends/processors/xapi/tests/test_transformers.py
@@ -42,8 +42,13 @@ class TestXApiTransformers(TransformersTestMixin, TestCase):
         if isinstance(expected_event, list):
             assert isinstance(transformed_event, list)
             assert len(transformed_event) == len(expected_event)
+            event_ids = set()
             for idx, e_event in enumerate(expected_event):
+                event_ids.add(transformed_event[idx].id)
                 self._compare_events(transformed_event[idx], e_event)
+
+            # Ensure a unique event ID was applied for the parent + child events
+            assert len(event_ids) == len(transformed_event)
 
         # Compare single events
         else:

--- a/event_routing_backends/processors/xapi/tests/test_xapi.py
+++ b/event_routing_backends/processors/xapi/tests/test_xapi.py
@@ -31,7 +31,7 @@ class TestXApiProcessor(SimpleTestCase):
     @patch('event_routing_backends.processors.mixins.base_transformer_processor.logger')
     def test_send_method_with_no_transformer_implemented(self, mocked_logger):
         with self.assertRaises(EventEmissionExit):
-            self.processor(self.sample_event)
+            self.processor([self.sample_event])
 
         mocked_logger.error.assert_called_once_with(
             'Could not get transformer for %s event.',
@@ -45,7 +45,7 @@ class TestXApiProcessor(SimpleTestCase):
     @patch('event_routing_backends.processors.mixins.base_transformer_processor.logger')
     def test_send_method_with_unknown_exception(self, mocked_logger, _):
         with self.assertRaises(ValueError):
-            self.processor(self.sample_event)
+            self.processor([self.sample_event])
 
         mocked_logger.exception.assert_called_once_with(
             'There was an error while trying to transform event "sentinel.name" using XApiProcessor'
@@ -62,7 +62,7 @@ class TestXApiProcessor(SimpleTestCase):
         mocked_transformer.transform.return_value = transformed_event
         mocked_get_transformer.return_value = mocked_transformer
 
-        self.processor(self.sample_event)
+        self.processor([self.sample_event])
 
         self.assertIn(call(transformed_event.to_json()), mocked_logger.mock_calls)
 
@@ -77,7 +77,7 @@ class TestXApiProcessor(SimpleTestCase):
         mocked_get_transformer.return_value = mocked_transformer
 
         with self.assertRaises(EventEmissionExit):
-            self.processor(self.sample_event)
+            self.processor([self.sample_event])
 
         self.assertNotIn(call(transformed_event.to_json()), mocked_logger.mock_calls)
 
@@ -93,7 +93,7 @@ class TestXApiProcessor(SimpleTestCase):
         mocked_transformer.transform.return_value = transformed_event
         mocked_get_transformer.return_value = mocked_transformer
 
-        self.processor(self.sample_event)
+        self.processor([self.sample_event])
 
         self.assertNotIn(call(transformed_event.to_json()), mocked_logger.mock_calls)
 
@@ -102,5 +102,5 @@ class TestXApiProcessor(SimpleTestCase):
         backend = XApiProcessor()
         backend.registry = None
         with self.assertRaises(EventEmissionExit):
-            self.assertIsNone(backend(self.sample_event))
+            self.assertIsNone(backend([self.sample_event]))
         mocked_logger.exception.assert_called_once()

--- a/event_routing_backends/processors/xapi/tests/test_xapi.py
+++ b/event_routing_backends/processors/xapi/tests/test_xapi.py
@@ -70,6 +70,21 @@ class TestXApiProcessor(SimpleTestCase):
         'event_routing_backends.processors.xapi.transformer_processor.XApiTransformersRegistry.get_transformer'
     )
     @patch('event_routing_backends.processors.xapi.transformer_processor.xapi_logger')
+    def test_send_method_with_event_list_successfull_flow(self, mocked_logger, mocked_get_transformer):
+        transformed_event = Statement()
+        transformed_event.object = Activity(id=str(uuid.uuid4()))
+        mocked_transformer = MagicMock()
+        mocked_transformer.transform.return_value = [transformed_event]
+        mocked_get_transformer.return_value = mocked_transformer
+
+        self.processor([self.sample_event])
+
+        self.assertIn(call(transformed_event.to_json()), mocked_logger.mock_calls)
+
+    @patch(
+        'event_routing_backends.processors.xapi.transformer_processor.XApiTransformersRegistry.get_transformer'
+    )
+    @patch('event_routing_backends.processors.xapi.transformer_processor.xapi_logger')
     def test_send_method_with_invalid_object(self, mocked_logger, mocked_get_transformer):
         transformed_event = Statement()
         mocked_transformer = MagicMock()

--- a/event_routing_backends/processors/xapi/transformer.py
+++ b/event_routing_backends/processors/xapi/transformer.py
@@ -46,22 +46,28 @@ class XApiTransformer(BaseTransformerMixin):
         transformed_props["version"] = constants.XAPI_SPECIFICATION_VERSION
         return Statement(**transformed_props)
 
-    def base_transform(self):
+    def base_transform(self, transformed_event):
         """
         Transform the fields that are common for all events.
         """
+        transformed_event = super().base_transform(transformed_event)
         actor = self.get_actor()
         event_timestamp = self.get_timestamp()
-        self.transformed_event = {
+        transformed_event.update({
             'actor': actor,
             'context': self.get_context(),
             'timestamp': event_timestamp,
-        }
+        })
+        transformed_event['actor'] = self.get_actor()
+        transformed_event['context'] = self.get_context()
+        transformed_event['timestamp'] = self.get_timestamp()
+
         # Warning! changing anything in these 2 lines or changing the "base_uuid" can invalidate
         # billions of rows in the database. Please have a community discussion first before introducing
         # any change in generation of UUID.
         uuid_str = f'{actor.to_json()}-{event_timestamp}'
-        self.transformed_event['id'] = get_uuid5(self.verb.to_json(), uuid_str)  # pylint: disable=no-member
+        transformed_event['id'] = get_uuid5(self.verb.to_json(), uuid_str)  # pylint: disable=no-member
+        return transformed_event
 
     def get_actor(self):
         """

--- a/event_routing_backends/processors/xapi/transformer.py
+++ b/event_routing_backends/processors/xapi/transformer.py
@@ -14,6 +14,7 @@ from tincan import (
     Extensions,
     LanguageMap,
     Statement,
+    StatementRef,
     Verb,
 )
 
@@ -177,4 +178,120 @@ class XApiVerbTransformerMixin:
         return Verb(
             id=verb['id'],
             display=LanguageMap({constants.EN: verb['display']})
+        )
+
+
+class OneToManyXApiTransformerMixin:
+    """
+    Abstract mixin that helps transform a single input event into:
+
+    * 1 parent xAPI event, plus
+    * N "child" xAPI events, where N>=0
+    """
+    @property
+    def child_transformer_class(self):
+        """
+        Abstract property which returns the transformer class to use when transforming the child events.
+
+        Should inherit from OneToManyChildXApiTransformerMixin.
+
+        Returns:
+            Type
+        """
+        raise NotImplementedError
+
+    def get_child_ids(self):
+        """
+        Abstract method which returns the list of "child" event IDs from the parent event data.
+
+        Returns:
+            list of strings
+        """
+        raise NotImplementedError
+
+    def transform(self):
+        """
+        Transform the edX event into a list of events, if there is child data.
+
+        If transform_child_events() is Falsey, then only the parent event is returned.
+        Otherwise, returns a list containing the parent event, followed by any child events.
+
+        Returns:
+            ANY, or list of ANY
+        """
+        parent_event = super().transform()
+        child_events = self.transform_children(parent_event)
+        if child_events:
+            return [parent_event, *child_events]
+        return parent_event
+
+    def transform_children(self, parent):
+        """
+        Transform the children of the parent xAPI event.
+
+
+        Returns:
+            list of ANY
+        """
+        child_ids = self.get_child_ids()
+        ChildTransformer = self.child_transformer_class
+        return [
+            ChildTransformer(
+                child_id=child_id,
+                parent=parent,
+                event=self.event,
+            ).transform() for child_id in child_ids
+        ]
+
+
+class OneToManyChildXApiTransformerMixin:
+    """
+    Mixin for processing child xAPI events from a parent transformer.
+
+    This class handles initialization, and adds methods for the expected stanzas in the transformed child event.
+
+    The parent event transformer should inherit from OneToManyXApiTransformer.
+    """
+    def __init__(self, parent, child_id, *args, **kwargs):
+        """
+        Stores the parent event transformer, and this child's identifier,
+        for use when transforming the child data.
+        """
+        super().__init__(*args, **kwargs)
+        self.parent = parent
+        self.child_id = child_id
+
+    def get_context(self):
+        """
+        Returns the context for the xAPI transformed child event.
+
+        Returns:
+            `Context`
+        """
+        return Context(
+            extensions=self.get_context_extensions(),
+            contextActivities=self.get_context_activities(),
+            statement=self.get_context_statement(),
+        )
+
+    def get_context_activities(self):
+        """
+        Get context activities for xAPI transformed event.
+
+        Returns:
+            `ContextActivities`
+        """
+        return ContextActivities(
+            parent=ActivityList([self.parent.object]),
+            grouping=ActivityList(self.parent.context.context_activities.parent),
+        )
+
+    def get_context_statement(self):
+        """
+        Returns a StatementRef that refers to the parent event.
+        Returns:
+            `StatementRef`
+        """
+        return StatementRef(
+            id=self.parent.id,
         )

--- a/event_routing_backends/processors/xapi/transformer_processor.py
+++ b/event_routing_backends/processors/xapi/transformer_processor.py
@@ -34,7 +34,7 @@ class XApiProcessor(BaseTransformerProcessorMixin):
             event (dict):   Event to be transformed.
 
         Returns:
-            dict:           transformed event
+            ANY:            transformed event
 
         Raises:
             Any Exception

--- a/event_routing_backends/processors/xapi/transformer_processor.py
+++ b/event_routing_backends/processors/xapi/transformer_processor.py
@@ -42,9 +42,15 @@ class XApiProcessor(BaseTransformerProcessorMixin):
         if not XAPI_EVENTS_ENABLED.is_enabled():
             raise NoBackendEnabled
 
-        transformed_event = super().transform_event(event)
+        transformed_events = super().transform_event(event)
+        if not transformed_events:
+            return None
 
-        if transformed_event:
+        if not isinstance(transformed_events, list):
+            transformed_events = [transformed_events]
+
+        returned_events = []
+        for transformed_event in transformed_events:
             event_json = transformed_event.to_json()
 
             if not transformed_event.object or not transformed_event.object.id:
@@ -55,6 +61,6 @@ class XApiProcessor(BaseTransformerProcessorMixin):
                 xapi_logger.info(event_json)
 
             logger.debug('xAPI statement of edx event "{}" is: {}'.format(event["name"], event_json))
-            return json.loads(event_json)
+            returned_events.append(json.loads(event_json))
 
-        return transformed_event
+        return returned_events


### PR DESCRIPTION
**Description:**

Updates the base event processor and tests to support transforming a single event into multiple events, and
modifies the server-side `problem_check`  xAPI event transformer to transform multi-problem submissions into:

* 1 event for the problem submission, plus
* 1 event for each sub-problem

Resolves https://github.com/openedx/event-routing-backends/issues/219

**JIRA:** [FAL-3430](https://tasks.opencraft.com/browse/FAL-3430) (OpenCraft internal link)

**Testing instructions:**

This change should be covered by tests, but to test it manually:

1. Install this branch on your Tutor LMS
2. Login, and submit various responses to the [Multiple Choice Questions](http://local.overhang.io:2000/course/course-v1:OpenCraft+DemoX+Demo/block-v1:OpenCraft+DemoX+Demo+type@sequential+block@basic_questions/block-v1:OpenCraft+DemoX+Demo+type@vertical+block@54bb9b142c6c4c22afc62bcb628f0e68) block in the Demo course, or create your own.
3. Watch multiple xAPI events flow through into Aspects from a single submission.

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** 

* Suggest reviewing this commit by commit to understand the reasoning.
* This change only affects xAPI, not Caliper events.
* Some minor changes to single question problem_check events occurred: added `object.definition.name` and `interactionType`.