### PR TITLE
fix: Retry getting bulk tracking logs

### DIFF
--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '5.5.4'
+__version__ = '5.5.5'

--- a/event_routing_backends/settings/common.py
+++ b/event_routing_backends/settings/common.py
@@ -13,6 +13,8 @@ def plugin_settings(settings):
     settings.XAPI_EVENT_LOGGING_ENABLED = True
     settings.EVENT_ROUTING_BACKEND_MAX_RETRIES = 3
     settings.EVENT_ROUTING_BACKEND_COUNTDOWN = 30
+    settings.EVENT_ROUTING_BACKEND_BULK_DOWNLOAD_MAX_RETRIES = 3
+    settings.EVENT_ROUTING_BACKEND_BULK_DOWNLOAD_COUNTDOWN = 1
 
     # .. setting_name: XAPI_AGENT_IFI_TYPE
     # .. setting_default: 'external_id'


### PR DESCRIPTION
**Description:** Forces retries when errors occur downloading tracking log chunks in bulk transform.

Fixes: #329 