### PR TITLE
fix: block events for missing courses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[7.0.1]
+
+* Do not send events for unknown courses
+
+[7.0.0]
+
+* Multi-question problem_check tracking log statements will now be split into one xAPI statement for each question
+
 [6.2.0]
 
 * Add support for completion events

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '7.0.0'
+__version__ = '7.0.1'

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -149,9 +149,7 @@ def get_course_from_id(course_id):
     course_overviews = get_course_overviews([course_key])
     if course_overviews:
         return course_overviews[0]
-    return {
-        "display_name": "Unknown Course",
-    }
+    raise ValueError(f"Course with id {course_id} does not exist.")
 
 
 def convert_seconds_to_iso(seconds):

--- a/event_routing_backends/tests/test_helpers.py
+++ b/event_routing_backends/tests/test_helpers.py
@@ -79,7 +79,7 @@ class TestHelpers(TestCase):
         self.assertNotEqual(uuid_1, uuid_3)
 
     @patch('event_routing_backends.helpers.get_course_overviews')
-    def test_get_course_from_id(self, mock_get_course_overviews):
+    def test_get_course_from_id_unknown_course(self, mock_get_course_overviews):
         mock_get_course_overviews.return_value = []
-        course = get_course_from_id("foo")
-        self.assertEqual(course["display_name"], "Unknown Course")
+        with self.assertRaises(ValueError):
+            get_course_from_id("foo")


### PR DESCRIPTION
**Description:**  A setting to allow to send missing courses

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
