### PR TITLE
feat!: add transformer to filter arguments.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,12 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+# Set the version of python needed to build these docs.
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 python:
-  version: 3.8
   install:
     - requirements: requirements/doc.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Unreleased
 [8.0.0]
 ~~~~~~~
 
-* Add transformer argument to openedx dynamic filter.
+* **BREAKING CHANGE**: Add transformer argument to openedx dynamic filter.
 
 [7.2.0]
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[8.0.0]
+~~~~~~~
+
+* Add transformer argument to openedx dynamic filter.
+
 [7.2.0]
 ~~~~~~~
 

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '7.2.0'
+__version__ = '8.0.0'

--- a/event_routing_backends/processors/openedx_filters/decorators.py
+++ b/event_routing_backends/processors/openedx_filters/decorators.py
@@ -41,6 +41,7 @@ def openedx_filter(filter_type):
             dynamic_filter = ProcessorBaseFilter.generate_dynamic_filter(filter_type=filter_type)
 
             return dynamic_filter.run_filter(
+                transformer=args[0],
                 result=func(*args, **kwargs),
             )
 

--- a/event_routing_backends/processors/openedx_filters/filters.py
+++ b/event_routing_backends/processors/openedx_filters/filters.py
@@ -28,11 +28,12 @@ class ProcessorBaseFilter(OpenEdxPublicFilter):
         return type("DynamicFilter", (cls,), {"filter_type": filter_type})
 
     @classmethod
-    def run_filter(cls, result):
+    def run_filter(cls, transformer, result):
         """
         Executes a filter after validating the right class configuration.
 
         Arguments:
+            transformer: XApiTransformer instance.
             result: Result to be modified or extended.
 
         Returns:
@@ -45,6 +46,6 @@ class ProcessorBaseFilter(OpenEdxPublicFilter):
         if not cls.filter_type:
             raise InvalidFilterType("Parameter filter_type has not been set.")
 
-        data = super().run_pipeline(result=result)
+        data = super().run_pipeline(transformer=transformer, result=result)
 
         return data.get("result", result)

--- a/event_routing_backends/processors/tests/openedx_filters/test_filters.py
+++ b/event_routing_backends/processors/tests/openedx_filters/test_filters.py
@@ -1,6 +1,6 @@
 """Test cases for the filters file."""
 from django.test import TestCase
-from mock import patch
+from mock import Mock, patch
 from openedx_filters.tooling import OpenEdxPublicFilter
 
 from event_routing_backends.processors.openedx_filters.exceptions import InvalidFilterType
@@ -17,7 +17,7 @@ class TestProcessorBaseFilter(TestCase):
         Expected behavior:
             - InvalidFilterType exception is raised
         """
-        self.assertRaises(InvalidFilterType, ProcessorBaseFilter.run_filter, "dummy_value")
+        self.assertRaises(InvalidFilterType, ProcessorBaseFilter.run_filter, Mock(), "dummy_value")
 
     @patch.object(OpenEdxPublicFilter, "run_pipeline")
     def test_expected_value(self, run_pipeline_mock):
@@ -28,13 +28,14 @@ class TestProcessorBaseFilter(TestCase):
             - run_pipeline is called with the right key and value
             - run_filter returns the value of the result key
         """
+        transformer = Mock()
         run_pipeline_mock.return_value = {
             "result": "expected_value"
         }
         input_value = "dummy_value"
         openedx_filter = ProcessorBaseFilter.generate_dynamic_filter(filter_type="test_filter")
 
-        result = openedx_filter.run_filter(result=input_value)
+        result = openedx_filter.run_filter(transformer=transformer, result=input_value)
 
-        run_pipeline_mock.assert_called_once_with(result=input_value)
+        run_pipeline_mock.assert_called_once_with(transformer=transformer, result=input_value)
         self.assertEqual(run_pipeline_mock()["result"], result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 7.2.0
+current_version = 8.0.0
 commit = False
 tag = False
 


### PR DESCRIPTION
**Description:** 
This improves the filter usability by adding the transformer to the filter arguments, basically this allows the filter client to access to extra data given by the transformer instance.

Current implementation just pass as argument the result of the decorated method, for example, the activity returned by this [method](https://github.com/openedx/event-routing-backends/blob/master/event_routing_backends/processors/xapi/event_transformers/enrollment_events.py#L30) however that activity or another result has limited information, for this example the filler would have something like 

```
   "object":{
      "id":"https://example.com/course/course-v1:edx+cs105+101_2023",
      "definition":{
         "name":{
            "en":" testing-course "
         },
         "type":"http://adlnet.gov/expapi/activities/course",
         "extensions":{
            "https://w3id.org/xapi/acrossx/extensions/type":"audit"
         }
      },
      "objectType":"Activity"
   }
```
In this case, if someone wants to get more data, for example, event_name, it's not possible, so adding the transformer instance  allows to the person who is developing the filter to  access instance methods and attributes like transformer.get_data()  or transformer.event

**Testing instructions:**

This works like another openedx-filter https://github.com/openedx/openedx-filters/

1. Define your pipeline, follow the openedx-filter instructions,finally the logic is up to you.A basic implementation could be the following
```
import logging
from openedx_filters import PipelineStep

LOGGER = logging.getLogger(__name__)

class Something(PipelineStep):

    def run_filter(self, transformer, result):
        LOGGER.info("I'm very happy with my first pipeline")
        return {
            "result": result
        }
```

2. include the configuration in your settings

```
OPEN_EDX_FILTERS_CONFIG = {
    "event_routing_backends.processors.xapi.transformer.xapi_transformer.get_actor": {
        "pipeline": ["path.to.the.class.Something"],
        "fail_silently": False,
    }
}
```
3. Raise any event and check that the pipeline logic was executed

## Note
This is a breaking change since current filters won't work with this version 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
