### PR TITLE
fix: remove tox-battery requirement and update tox

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
 aniso8601==9.0.1
     # via tincan
@@ -16,19 +16,19 @@ backports-zoneinfo[tzdata]==0.2.1
     # via
     #   celery
     #   kombu
-billiard==4.1.0
+billiard==4.2.0
     # via celery
-celery==5.3.4
+celery==5.3.6
     # via
     #   edx-celeryutils
     #   event-tracking
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
@@ -46,9 +46,9 @@ click-repl==0.3.0
     # via celery
 code-annotations==1.5.0
     # via edx-toggles
-cryptography==41.0.3
+cryptography==41.0.7
     # via django-fernet-fields-v2
-django==3.2.21
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -64,7 +64,7 @@ django==3.2.21
     #   event-tracking
     #   jsonfield
     #   openedx-filters
-django-config-models==2.5.0
+django-config-models==2.5.1
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -82,7 +82,7 @@ djangorestframework==3.14.0
     # via django-config-models
 edx-celeryutils==1.2.3
     # via -r requirements/base.in
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via
     #   django-config-models
     #   edx-toggles
@@ -91,9 +91,9 @@ edx-toggles==5.1.0
     # via -r requirements/base.in
 event-tracking==2.2.0
     # via -r requirements/base.in
-fasteners==0.18
+fasteners==0.19
     # via -r requirements/base.in
-idna==3.4
+idna==3.6
     # via requests
 isodate==0.6.1
     # via -r requirements/base.in
@@ -103,19 +103,19 @@ jsonfield==3.1.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
-kombu==5.3.2
+kombu==5.3.4
     # via celery
 markupsafe==2.1.3
     # via jinja2
-newrelic==9.0.0
+newrelic==9.3.0
     # via edx-django-utils
 openedx-filters==1.6.0
     # via -r requirements/base.in
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -157,7 +157,7 @@ text-unidecode==1.3
     # via python-slugify
 tincan==1.0.0
     # via -r requirements/base.in
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   asgiref
     #   kombu
@@ -165,12 +165,12 @@ tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
-urllib3==2.0.4
+urllib3==2.1.0
     # via requests
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.6
+wcwidth==0.2.12
     # via prompt-toolkit

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,29 +4,35 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-packaging==23.1
-    # via tox
-platformdirs==3.10.0
-    # via virtualenv
+packaging==23.2
+    # via
+    #   pyproject-api
+    #   tox
+platformdirs==4.1.0
+    # via
+    #   tox
+    #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/ci.in
-typing-extensions==4.7.1
-    # via filelock
-virtualenv==20.24.5
+    #   pyproject-api
+    #   tox
+tox==4.11.4
+    # via -r requirements/ci.in
+virtualenv==20.25.0
     # via tox

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,4 +7,3 @@
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/quality.txt
     #   kombu
@@ -12,7 +12,7 @@ aniso8601==9.0.1
     # via
     #   -r requirements/quality.txt
     #   tincan
-annotated-types==0.5.0
+annotated-types==0.6.0
     # via pydantic
 apache-libcloud==3.8.0
     # via -r requirements/quality.txt
@@ -20,7 +20,7 @@ asgiref==3.7.2
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.6
+astroid==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -28,9 +28,10 @@ astroid==2.15.6
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/quality.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/quality.txt
     #   celery
@@ -38,21 +39,29 @@ build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-celery==5.3.4
+cachetools==5.3.2
+    # via
+    #   -r requirements/ci.txt
+    #   tox
+celery==5.3.6
     # via
     #   -r requirements/quality.txt
     #   edx-celeryutils
     #   event-tracking
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements/quality.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+chardet==5.2.0
+    # via
+    #   -r requirements/ci.txt
+    #   tox
+charset-normalizer==3.3.2
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -90,15 +99,20 @@ code-annotations==1.5.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.3.1
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
+coverage[toml]==7.3.2
     # via
     #   -r requirements/quality.txt
+    #   coverage
     #   pytest-cov
-cryptography==41.0.3
+cryptography==41.0.7
     # via
     #   -r requirements/quality.txt
     #   django-fernet-fields-v2
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/quality.txt
 diff-cover==4.0.0
     # via
@@ -112,7 +126,7 @@ distlib==0.3.7
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.21
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -129,7 +143,7 @@ django==3.2.21
     #   event-tracking
     #   jsonfield
     #   openedx-filters
-django-config-models==2.5.0
+django-config-models==2.5.1
     # via -r requirements/quality.txt
 django-crum==0.7.9
     # via
@@ -153,42 +167,42 @@ djangorestframework==3.14.0
     #   django-config-models
 edx-celeryutils==1.2.3
     # via -r requirements/quality.txt
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/quality.txt
     #   django-config-models
     #   edx-toggles
     #   event-tracking
-edx-i18n-tools==1.1.0
+edx-i18n-tools==1.3.0
     # via -r requirements/dev.in
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/quality.txt
 edx-toggles==5.1.0
     # via -r requirements/quality.txt
 event-tracking==2.2.0
     # via -r requirements/quality.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/quality.txt
-faker==19.6.1
+faker==20.1.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
-fasteners==0.18
+fasteners==0.19
     # via -r requirements/quality.txt
-filelock==3.12.3
+filelock==3.13.1
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
@@ -216,14 +230,12 @@ jsonfield==3.1.0
     # via
     #   -r requirements/quality.txt
     #   edx-celeryutils
-kombu==5.3.2
+kombu==5.3.4
     # via
     #   -r requirements/quality.txt
     #   celery
-lazy-object-proxy==1.9.0
-    # via
-    #   -r requirements/quality.txt
-    #   astroid
+lxml==4.9.3
+    # via edx-i18n-tools
 markupsafe==2.1.3
     # via
     #   -r requirements/quality.txt
@@ -234,33 +246,35 @@ mccabe==0.7.0
     #   pylint
 mock==5.1.0
     # via -r requirements/quality.txt
-newrelic==9.0.0
+newrelic==9.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
 openedx-filters==1.6.0
     # via -r requirements/quality.txt
-packaging==23.1
+packaging==23.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   tox
-path==16.7.1
+path==16.9.0
     # via edx-i18n-tools
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
 pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.10.0
+platformdirs==4.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -271,33 +285,29 @@ pluggy==1.3.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via
     #   -r requirements/quality.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-py==1.11.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via -r requirements/quality.txt
 pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pydantic==2.3.0
+pydantic==2.5.2
     # via inflect
-pydantic-core==2.6.3
+pydantic-core==2.14.5
     # via pydantic
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.16.1
+pygments==2.17.2
     # via diff-cover
-pylint==2.17.5
+pylint==3.0.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -308,7 +318,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -325,18 +335,22 @@ pynacl==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/quality.txt
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements/quality.txt
 python-dateutil==2.8.2
     # via
@@ -365,13 +379,11 @@ requests==2.31.0
     #   apache-libcloud
 six==1.16.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
     #   event-tracking
     #   isodate
     #   python-dateutil
-    #   tox
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
@@ -400,29 +412,23 @@ tomli==2.0.1
     #   coverage
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.28.0
+tox==4.11.4
+    # via -r requirements/ci.txt
+typing-extensions==4.8.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/dev.in
-typing-extensions==4.7.1
-    # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   annotated-types
     #   asgiref
     #   astroid
     #   faker
-    #   filelock
     #   inflect
     #   kombu
     #   pydantic
@@ -433,33 +439,29 @@ tzdata==2023.3
     #   -r requirements/quality.txt
     #   backports-zoneinfo
     #   celery
-urllib3==2.0.4
+urllib3==2.1.0
     # via
     #   -r requirements/quality.txt
     #   requests
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/quality.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.5
+virtualenv==20.25.0
     # via
     #   -r requirements/ci.txt
     #   tox
-wcwidth==0.2.6
+wcwidth==0.2.12
     # via
     #   -r requirements/quality.txt
     #   prompt-toolkit
-wheel==0.41.2
+wheel==0.42.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.15.0
-    # via
-    #   -r requirements/quality.txt
-    #   astroid
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   -r requirements/pip-tools.txt
     #   importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,7 +8,7 @@ accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -22,38 +22,39 @@ asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
-babel==2.12.1
+babel==2.13.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/test.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/test.txt
     #   celery
 build==1.0.3
     # via -r requirements/doc.in
-celery==5.3.4
+celery==5.3.6
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
     #   event-tracking
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -82,18 +83,18 @@ code-annotations==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
-coverage[toml]==7.3.1
+coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
-cryptography==41.0.3
+cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   django-fernet-fields-v2
-    #   secretstorage
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.txt
-django==3.2.21
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -109,7 +110,7 @@ django==3.2.21
     #   event-tracking
     #   jsonfield
     #   openedx-filters
-django-config-models==2.5.0
+django-config-models==2.5.1
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -145,7 +146,7 @@ docutils==0.17.1
     #   sphinx
 edx-celeryutils==1.2.3
     # via -r requirements/test.txt
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -155,30 +156,30 @@ edx-toggles==5.1.0
     # via -r requirements/test.txt
 event-tracking==2.2.0
     # via -r requirements/test.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==19.6.1
+faker==20.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fasteners==0.18
+fasteners==0.19
     # via -r requirements/test.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   build
     #   keyring
     #   twine
-importlib-resources==6.0.1
+importlib-resources==6.1.1
     # via keyring
 iniconfig==2.0.0
     # via
@@ -188,10 +189,6 @@ isodate==0.6.1
     # via -r requirements/test.txt
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -201,9 +198,9 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-keyring==24.2.0
+keyring==24.3.0
     # via twine
-kombu==5.3.2
+kombu==5.3.4
     # via
     #   -r requirements/test.txt
     #   celery
@@ -219,22 +216,22 @@ mock==5.1.0
     # via -r requirements/test.txt
 more-itertools==10.1.0
     # via jaraco-classes
-newrelic==9.0.0
+newrelic==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
 openedx-filters==1.6.0
     # via -r requirements/test.txt
-packaging==23.1
+packaging==23.2
     # via
     #   -r requirements/test.txt
     #   build
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -244,11 +241,11 @@ pluggy==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -258,7 +255,7 @@ pycparser==2.21
     #   cffi
 pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   accessible-pygments
     #   doc8
@@ -276,14 +273,14 @@ pynacl==1.5.0
     #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.txt
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -321,10 +318,8 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.5.2
+rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -380,7 +375,7 @@ tomli==2.0.1
     #   pytest
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   -r requirements/test.txt
     #   asgiref
@@ -393,22 +388,22 @@ tzdata==2023.3
     #   -r requirements/test.txt
     #   backports-zoneinfo
     #   celery
-urllib3==2.0.4
+urllib3==2.1.0
     # via
     #   -r requirements/test.txt
     #   requests
     #   twine
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/test.txt
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.6
+wcwidth==0.2.12
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
-zipp==3.16.2
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via build
-packaging==23.1
+packaging==23.2
     # via build
 pip-tools==7.3.0
     # via -r requirements/pip-tools.in
@@ -21,9 +21,9 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.2
+wheel==0.42.0
     # via pip-tools
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.41.2
+wheel==0.42.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.2.1
+pip==23.3.1
     # via -r requirements/pip.in
-setuptools==68.2.2
+setuptools==69.0.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -18,34 +18,35 @@ asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.6
+astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/test.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/test.txt
     #   celery
-celery==5.3.4
+celery==5.3.6
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
     #   event-tracking
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -79,19 +80,20 @@ code-annotations==1.5.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.3.1
+coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
-cryptography==41.0.3
+cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   django-fernet-fields-v2
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.txt
 dill==0.3.7
     # via pylint
-django==3.2.21
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -107,7 +109,7 @@ django==3.2.21
     #   event-tracking
     #   jsonfield
     #   openedx-filters
-django-config-models==2.5.0
+django-config-models==2.5.1
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -131,31 +133,31 @@ djangorestframework==3.14.0
     #   django-config-models
 edx-celeryutils==1.2.3
     # via -r requirements/test.txt
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
     #   edx-toggles
     #   event-tracking
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/quality.in
 edx-toggles==5.1.0
     # via -r requirements/test.txt
 event-tracking==2.2.0
     # via -r requirements/test.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==19.6.1
+faker==20.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fasteners==0.18
+fasteners==0.19
     # via -r requirements/test.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
@@ -177,12 +179,10 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-kombu==5.3.2
+kombu==5.3.4
     # via
     #   -r requirements/test.txt
     #   celery
-lazy-object-proxy==1.9.0
-    # via astroid
 markupsafe==2.1.3
     # via
     #   -r requirements/test.txt
@@ -191,35 +191,35 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.txt
-newrelic==9.0.0
+newrelic==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 openedx-filters==1.6.0
     # via -r requirements/test.txt
-packaging==23.1
+packaging==23.2
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.10.0
+platformdirs==4.1.0
     # via pylint
 pluggy==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via
     #   -r requirements/test.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via -r requirements/quality.in
 pycparser==2.21
     # via
@@ -227,7 +227,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.5
+pylint==3.0.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -235,7 +235,7 @@ pylint==2.17.5
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via edx-lint
 pylint-plugin-utils==0.8.2
     # via
@@ -249,14 +249,14 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.txt
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -312,9 +312,9 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   -r requirements/test.txt
     #   asgiref
@@ -327,19 +327,17 @@ tzdata==2023.3
     #   -r requirements/test.txt
     #   backports-zoneinfo
     #   celery
-urllib3==2.0.4
+urllib3==2.1.0
     # via
     #   -r requirements/test.txt
     #   requests
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/test.txt
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.6
+wcwidth==0.2.12
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
-wrapt==1.15.0
-    # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -21,27 +21,28 @@ asgiref==3.7.2
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/base.txt
+    #   backports-zoneinfo
     #   celery
     #   kombu
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.3.4
+celery==5.3.6
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
     #   event-tracking
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
     #   requests
@@ -71,13 +72,15 @@ code-annotations==1.5.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==7.3.1
-    # via pytest-cov
-cryptography==41.0.3
+coverage[toml]==7.3.2
+    # via
+    #   coverage
+    #   pytest-cov
+cryptography==41.0.7
     # via
     #   -r requirements/base.txt
     #   django-fernet-fields-v2
-ddt==1.6.0
+ddt==1.7.0
     # via -r requirements/test.in
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -94,7 +97,7 @@ ddt==1.6.0
     #   event-tracking
     #   jsonfield
     #   openedx-filters
-django-config-models==2.5.0
+django-config-models==2.5.1
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -118,7 +121,7 @@ djangorestframework==3.14.0
     #   django-config-models
 edx-celeryutils==1.2.3
     # via -r requirements/base.txt
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -128,15 +131,15 @@ edx-toggles==5.1.0
     # via -r requirements/base.txt
 event-tracking==2.2.0
     # via -r requirements/base.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==19.6.1
+faker==20.1.0
     # via factory-boy
-fasteners==0.18
+fasteners==0.19
     # via -r requirements/base.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
@@ -152,7 +155,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-kombu==5.3.2
+kombu==5.3.4
     # via
     #   -r requirements/base.txt
     #   celery
@@ -162,25 +165,25 @@ markupsafe==2.1.3
     #   jinja2
 mock==5.1.0
     # via -r requirements/test.in
-newrelic==9.0.0
+newrelic==9.3.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
 openedx-filters==1.6.0
     # via -r requirements/base.txt
-packaging==23.1
+packaging==23.2
     # via pytest
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
 pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via
     #   -r requirements/base.txt
     #   click-repl
-psutil==5.9.5
+psutil==5.9.6
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -196,13 +199,13 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   pytest-cov
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-django==4.5.2
+pytest-django==4.7.0
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
@@ -253,7 +256,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   -r requirements/base.txt
     #   asgiref
@@ -264,17 +267,17 @@ tzdata==2023.3
     #   -r requirements/base.txt
     #   backports-zoneinfo
     #   celery
-urllib3==2.0.4
+urllib3==2.1.0
     # via
     #   -r requirements/base.txt
     #   requests
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/base.txt
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.6
+wcwidth==0.2.12
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit


### PR DESCRIPTION
## Description
- Remove `tox-battery` from requirements since it is not needed for `tox>3` anymore.
- Updated `tox` to `v4`.