### PR TITLE
fix: dinamically get the block-id version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[8.1.1]
+
+* Dinamically get the xblock version from the event.
+
 [8.1.0]
 ~~~~~~~
 

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '8.1.0'
+__version__ = '8.1.1'

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -242,7 +242,10 @@ def get_block_id_from_event_data(data, course_id):
     if data is not None and course_id is not None:
         data_array = data.split('_')
         course_id_array = course_id.split(':')
-        block_id = "block-v1:{}+type@problem+block@{}".format(course_id_array[1], data_array[1]) \
+        block_version = "block-{0}".format(course_id_array[0].split("-")[-1])
+        if "ccx" in course_id_array[0]:
+            block_version = "ccx-{block_version}".format(block_version=block_version)
+        block_id = "{}:{}+type@problem+block@{}".format(block_version, course_id_array[1], data_array[1]) \
             if len(data_array) > 1 and len(course_id_array) > 1 else None
     else:
         block_id = None
@@ -272,7 +275,7 @@ def get_problem_block_id(referrer, data, course_id):
     return block_id
 
 
-def make_video_block_id(video_id, course_id, video_block_name='video', block_version='block-v1'):
+def make_video_block_id(video_id, course_id, video_block_name='video'):
     """
     Return formatted video block id for provided video and course.
 
@@ -280,12 +283,14 @@ def make_video_block_id(video_id, course_id, video_block_name='video', block_ver
         video_id        (str) : id for the video object
         course_id       (str) : course key string
         video_block_name(str) : video block prefix to generate video id
-        block_version   (str) : xBlock version
 
     Returns:
         str
     """
     course_id_array = course_id.split(':')
+    block_version = "block-{0}".format(course_id_array[0].split("-")[-1])
+    if "ccx" in course_id_array[0]:
+        block_version = "ccx-{block_version}".format(block_version=block_version)
     return '{block_version}:{course_id}+type@{video_block_name}+block@{video_id}'.format(
         block_version=block_version,
         course_id=course_id_array[1],

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -252,7 +252,7 @@ def get_block_id_from_event_data(data, course_id):
                 block_id=data_array[1]
             )
         else:
-            block_id = None
+            block_id = None  # pragma: no cover
     else:
         block_id = None
 

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -23,6 +23,7 @@ User = get_user_model()
 UTC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 BLOCK_ID_FORMAT = '{block_version}:{course_id}+type@{block_type}+block@{block_id}'
 
+
 def get_uuid5(namespace_key, name):
     """
     Create a UUID5 string based on custom namesapce and name.
@@ -323,6 +324,7 @@ def get_business_critical_events():
         'edx.course.enrollment.deactivated',
         'edx.course.grade.passed.first_time'
     ])
+
 
 def get_block_version(course_id):
     """

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 UTC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
-
+BLOCK_ID_FORMAT = '{block_version}:{course_id}+type@{block_type}+block@{block_id}'
 
 def get_uuid5(namespace_key, name):
     """
@@ -242,11 +242,16 @@ def get_block_id_from_event_data(data, course_id):
     if data is not None and course_id is not None:
         data_array = data.split('_')
         course_id_array = course_id.split(':')
-        block_version = "block-{0}".format(course_id_array[0].split("-")[-1])
-        if "ccx" in course_id_array[0]:
-            block_version = "ccx-{block_version}".format(block_version=block_version)
-        block_id = "{}:{}+type@problem+block@{}".format(block_version, course_id_array[1], data_array[1]) \
-            if len(data_array) > 1 and len(course_id_array) > 1 else None
+        block_version = get_block_version(course_id)
+        if len(data_array) > 1 and len(course_id_array) > 1:
+            block_id = BLOCK_ID_FORMAT.format(
+                block_version=block_version,
+                course_id=course_id_array[1],
+                block_type='problem',
+                block_id=data_array[1]
+            )
+        else:
+            block_id = None
     else:
         block_id = None
 
@@ -275,27 +280,24 @@ def get_problem_block_id(referrer, data, course_id):
     return block_id
 
 
-def make_video_block_id(video_id, course_id, video_block_name='video'):
+def make_video_block_id(video_id, course_id):
     """
     Return formatted video block id for provided video and course.
 
     Arguments:
         video_id        (str) : id for the video object
         course_id       (str) : course key string
-        video_block_name(str) : video block prefix to generate video id
 
     Returns:
         str
     """
     course_id_array = course_id.split(':')
-    block_version = "block-{0}".format(course_id_array[0].split("-")[-1])
-    if "ccx" in course_id_array[0]:
-        block_version = "ccx-{block_version}".format(block_version=block_version)
-    return '{block_version}:{course_id}+type@{video_block_name}+block@{video_id}'.format(
+    block_version = get_block_version(course_id)
+    return BLOCK_ID_FORMAT.format(
         block_version=block_version,
         course_id=course_id_array[1],
-        video_block_name=video_block_name,
-        video_id=video_id
+        block_type='video',
+        block_id=video_id
     )
 
 
@@ -321,3 +323,20 @@ def get_business_critical_events():
         'edx.course.enrollment.deactivated',
         'edx.course.grade.passed.first_time'
     ])
+
+def get_block_version(course_id):
+    """
+    Return versioned block id.
+
+    Arguments:
+        course_id (str):    course id
+        block_id (str):     block id
+
+    Returns:
+        str
+    """
+    course_id_array = course_id.split(':')
+    block_version = "block-{0}".format(course_id_array[0].split("-")[-1])
+    if "ccx" in course_id_array[0]:
+        block_version = "ccx-{block_version}".format(block_version=block_version)
+    return block_version

--- a/event_routing_backends/processors/tests/fixtures/current/play_video.ccx.json
+++ b/event_routing_backends/processors/tests/fixtures/current/play_video.ccx.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "accept_language": "en-US,en;q=0.9",
+        "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
+        "client_id": "667522224.1583394645",
+        "course_id": "ccx-v1:edX+DemoX+Demo_Course+ccx@1",
+        "event_source": "browser",
+        "host": "localhost:18000",
+        "ip": "172.18.0.1",
+        "org_id": "edX",
+        "page": "http://localhost:18000/courses/ccx-block-v1:edX+DemoX+Demo_Course+ccx@1/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40edx_introduction",
+        "path": "/event",
+        "referer": "http://localhost:18000/courses/ccx-block-v1:edX+DemoX+Demo_Course+ccx@1/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40edx_introduction",
+        "session": "993110e9c27848a545da74a74114158d",
+        "user_id": 3,
+        "username": "edx"
+    },
+    "data": {
+        "code": "b7xgknqkQk8",
+        "currentTime": 0.03278805340576172,
+        "duration": 195,
+        "id": "0b9e39477cf34507a7a48f74be381fdd"
+    },
+    "name": "play_video",
+    "timestamp": "2020-07-15T06:52:55.057099+00:00"
+}

--- a/event_routing_backends/processors/tests/fixtures/current/problem_check(browser).ccx.json
+++ b/event_routing_backends/processors/tests/fixtures/current/problem_check(browser).ccx.json
@@ -1,0 +1,21 @@
+{
+    "context": {
+        "accept_language": "en-US,en;q=0.9",
+        "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
+        "client_id": "667522224.1583394645",
+        "course_id": "ccx-v1:edX+DemoX+Demo_Course+ccx@1",
+        "event_source": "browser",
+        "host": "localhost:18000",
+        "ip": "172.18.0.1",
+        "org_id": "edX",
+        "page": "http://localhost:18000/courses/ccx-block-v1:edX+DemoX+Demo_Course+ccx@1/courseware/8b66dcd2d6134eda9355089ece4f39f6/ef37eb3cf1724e38b7f88a9ce85a4842/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40ef37eb3cf1724e38b7f88a9ce85a4842",
+        "path": "/event",
+        "referer": "http://localhost:18000/xblock/ccx-block-v1:edX+DemoX+Demo_Course+ccx@1+type@vertical+block@e3601c0abee6427d8c17e6d6f8fdddd1?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view",
+        "session": "6ad0a24d8303f49d14409a669d430b6f",
+        "user_id": 3,
+        "username": "edx"
+    },
+    "data": "input_3fc5461f86764ad7bdbdf6cbdde61e66_2_1%5B%5D=choice_0&input_3fc5461f86764ad7bdbdf6cbdde61e66_2_1%5B%5D=choice_2",
+    "name": "problem_check",
+    "timestamp": "2020-07-14T14:39:26.580443+00:00"
+}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.ccx.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.ccx.json
@@ -1,0 +1,48 @@
+{
+    "id": "203e182c-6a2d-5458-9c61-a271297d459a",
+    "actor": {
+        "objectType": "Agent",
+        "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}
+    },
+    "context": {
+        "contextActivities": {
+            "parent": [
+                {
+                    "id": "http://localhost:18000/course/ccx-v1:edX+DemoX+Demo_Course+ccx@1",
+                    "objectType": "Activity",
+                    "definition": {
+                      "name": {
+                        "en-US": "Demonstration Course"
+                      },
+                      "type": "http://adlnet.gov/expapi/activities/course"
+                    }
+                }
+            ]
+        },
+        "extensions": {
+            "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+            "https://w3id.org/xapi/openedx/extensions/session-id": "993110e9c27848a545da74a74114158d",
+            "https://w3id.org/xapi/video/extensions/length": 195.0
+        }
+    },
+    "object": {
+        "definition": {
+            "type": "https://w3id.org/xapi/video/activity-type/video"
+        },
+        "id": "http://localhost:18000/xblock/ccx-block-v1:edX+DemoX+Demo_Course+ccx@1+type@video+block@0b9e39477cf34507a7a48f74be381fdd",
+        "objectType": "Activity"
+    },
+    "result": {
+        "extensions": {
+            "https://w3id.org/xapi/video/extensions/time": 0.033
+        }
+    },
+    "timestamp": "2020-07-15T06:52:55.057099+00:00",
+    "verb": {
+        "display": {
+            "en": "played"
+        },
+        "id": "https://w3id.org/xapi/video/verbs/played"
+    },
+    "version": "1.0.3"
+}

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).ccx.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).ccx.json
@@ -1,0 +1,43 @@
+{
+    "id": "2a1f0f7c-6636-52df-913b-59e2f197a58e",
+    "actor": {
+        "objectType": "Agent",
+        "account": {"homePage": "http://localhost:18000", "name": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"}
+    },
+    "context": {
+        "contextActivities": {
+            "parent": [
+                {
+                    "id": "http://localhost:18000/course/ccx-v1:edX+DemoX+Demo_Course+ccx@1",
+                    "objectType": "Activity",
+                    "definition": {
+                      "name": {
+                        "en-US": "Demonstration Course"
+                      },
+                      "type": "http://adlnet.gov/expapi/activities/course"
+                    }
+                }
+            ]
+        },
+        "extensions": {
+            "https://w3id.org/xapi/openedx/extension/transformer-version": "event-routing-backends@1.1.1",
+            "https://w3id.org/xapi/openedx/extensions/session-id": "6ad0a24d8303f49d14409a669d430b6f"
+        }
+    },
+    "object": {
+        "definition": {
+            "interactionType": "other",
+            "type": "http://adlnet.gov/expapi/activities/cmi.interaction"
+        },
+        "id": "http://localhost:18000/xblock/ccx-block-v1:edX+DemoX+Demo_Course+ccx@1+type@problem+block@3fc5461f86764ad7bdbdf6cbdde61e66",
+        "objectType": "Activity"
+    },
+    "timestamp": "2020-07-14T14:39:26.580443+00:00",
+    "verb": {
+        "display": {
+            "en": "attempted"
+        },
+        "id": "http://adlnet.gov/expapi/verbs/attempted"
+    },
+    "version": "1.0.3"
+}


### PR DESCRIPTION
**Description:** This PR dinamically gets the block-id version from the `block_id` string. Support CCX courses.

**Testing instructions:**

1. Enable CCX courses
2. Configure a Course as a CCX master
3. Create a CCX child course
4. Emit a video event and a problem event
5. Make sure the corresponding xAPI event has the block ID serialized correctly, verifying that the `object.id` URL points to the right CCX object.
