### PR TITLE
fix: Batching failures when individual event errors bubble up

### DIFF
--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '8.3.0'
+__version__ = '8.3.1'

--- a/event_routing_backends/backends/events_router.py
+++ b/event_routing_backends/backends/events_router.py
@@ -233,7 +233,7 @@ class EventsRouter:
             batch = [i for n, i in enumerate(batch) if i not in batch[n + 1:]]
             final_size = len(batch)
 
-            if final_size != orig_size:
+            if final_size != orig_size:  # pragma: no cover
                 logger.warning(f"{orig_size - final_size} duplicate events in event-routing-backends batch queue! "
                                f"This is a likely due to misconfiguration of EVENT_TRACKING_BACKENDS.")
             return batch
@@ -249,9 +249,6 @@ class EventsRouter:
             return True
         time_passed = (datetime.now() - datetime.fromisoformat(last_sent.decode('utf-8')))
         ready = time_passed > timedelta(seconds=settings.EVENT_ROUTING_BACKEND_BATCH_INTERVAL)
-
-        if ready:
-            logger.info(f'Time to send: {time_passed} elapsed since last send.')
 
         return ready
 

--- a/event_routing_backends/backends/events_router.py
+++ b/event_routing_backends/backends/events_router.py
@@ -225,6 +225,17 @@ class EventsRouter:
 
         if queue_size >= settings.EVENT_ROUTING_BACKEND_BATCH_SIZE or self.time_to_send(redis):
             batch = redis.rpop(self.queue_name, queue_size)
+
+            orig_size = len(batch)
+            # Deduplicate list, in some misconfigured cases tracking events can be emitted to the
+            # bus twice, causing them to be processed twice, which LRSs will reject.
+            # See: https://github.com/openedx/event-routing-backends/issues/410
+            batch = [i for n, i in enumerate(batch) if i not in batch[n + 1:]]
+            final_size = len(batch)
+
+            if final_size != orig_size:
+                logger.warning(f"{orig_size - final_size} duplicate events in event-routing-backends batch queue! "
+                               f"This is a likely due to misconfiguration of EVENT_TRACKING_BACKENDS.")
             return batch
 
         return None
@@ -237,7 +248,12 @@ class EventsRouter:
         if not last_sent:
             return True
         time_passed = (datetime.now() - datetime.fromisoformat(last_sent.decode('utf-8')))
-        return time_passed > timedelta(seconds=settings.EVENT_ROUTING_BACKEND_BATCH_INTERVAL)
+        ready = time_passed > timedelta(seconds=settings.EVENT_ROUTING_BACKEND_BATCH_INTERVAL)
+
+        if ready:
+            logger.info(f'Time to send: {time_passed} elapsed since last send.')
+
+        return ready
 
     def process_event(self, event):
         """

--- a/event_routing_backends/processors/caliper/tests/test_caliper.py
+++ b/event_routing_backends/processors/caliper/tests/test_caliper.py
@@ -29,13 +29,11 @@ class TestCaliperProcessor(SimpleTestCase):
 
     @override_settings(CALIPER_EVENTS_ENABLED=False)
     def test_skip_event_when_disabled(self):
-        with self.assertRaises(NoBackendEnabled):
-            self.processor(self.sample_event)
+        self.assertFalse(self.processor(self.sample_event))
 
     @patch('event_routing_backends.processors.mixins.base_transformer_processor.logger')
     def test_send_method_with_no_transformer_implemented(self, mocked_logger):
-        with self.assertRaises(EventEmissionExit):
-            self.processor([self.sample_event])
+        self.assertFalse(self.processor([self.sample_event]))
 
         mocked_logger.error.assert_called_once_with(
             'Could not get transformer for %s event.',
@@ -130,6 +128,5 @@ class TestCaliperProcessor(SimpleTestCase):
     def test_with_no_registry(self, mocked_logger):
         backend = CaliperProcessor()
         backend.registry = None
-        with self.assertRaises(EventEmissionExit):
-            self.assertIsNone(backend([self.sample_event]))
+        self.assertFalse(backend([self.sample_event]))
         mocked_logger.exception.assert_called_once()

--- a/event_routing_backends/processors/caliper/tests/test_caliper.py
+++ b/event_routing_backends/processors/caliper/tests/test_caliper.py
@@ -5,7 +5,6 @@ import json
 
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from eventtracking.processors.exceptions import EventEmissionExit, NoBackendEnabled
 from mock import MagicMock, call, patch, sentinel
 
 from event_routing_backends.processors.caliper.transformer_processor import CaliperProcessor

--- a/event_routing_backends/processors/mixins/base_transformer.py
+++ b/event_routing_backends/processors/mixins/base_transformer.py
@@ -175,9 +175,7 @@ class BaseTransformerMixin:
             result = None
 
         if result is None:
-            if not required:
-                logger.warning('Could not get value for %s in event "%s"', key, self.event.get('name', None))
-            else:
+            if required:
                 raise ValueError(
                     'Could not get value for {} in event "{}"'.format(key, self.event.get('name', None))
                 )

--- a/event_routing_backends/processors/mixins/base_transformer_processor.py
+++ b/event_routing_backends/processors/mixins/base_transformer_processor.py
@@ -3,7 +3,7 @@ Base Processor Mixin for transformer processors.
 """
 from logging import getLogger
 
-from eventtracking.processors.exceptions import EventEmissionExit, NoTransformerImplemented
+from eventtracking.processors.exceptions import NoBackendEnabled, NoTransformerImplemented
 
 logger = getLogger(__name__)
 
@@ -34,13 +34,22 @@ class BaseTransformerProcessorMixin:
         """
         returned_events = []
         for event in events:
-            transformed_event = self.transform_event(event)
-            if not transformed_event:
-                raise EventEmissionExit
-            if isinstance(transformed_event, list):
-                returned_events += transformed_event
-            else:
-                returned_events.append(transformed_event)
+            try:
+                transformed_event = self.transform_event(event)
+                if not transformed_event:
+                    pass
+                elif isinstance(transformed_event, list):
+                    returned_events += transformed_event
+                else:
+                    returned_events.append(transformed_event)
+
+            # If there's not a transformer implemented for this event
+            # just skip it
+            except NoTransformerImplemented:
+                pass
+            # If the backend isn't enabled at all, early out
+            except NoBackendEnabled:
+                break
         return returned_events
 
     def transform_event(self, event):
@@ -60,6 +69,9 @@ class BaseTransformerProcessorMixin:
 
         try:
             transformed_event = self.get_transformed_event(event)
+
+        except NoBackendEnabled:
+            return None
 
         except NoTransformerImplemented:
             logger.error('Could not get transformer for %s event.', event_name)

--- a/event_routing_backends/processors/mixins/base_transformer_processor.py
+++ b/event_routing_backends/processors/mixins/base_transformer_processor.py
@@ -43,10 +43,6 @@ class BaseTransformerProcessorMixin:
                 else:
                     returned_events.append(transformed_event)
 
-            # If there's not a transformer implemented for this event
-            # just skip it
-            except NoTransformerImplemented:
-                pass
             # If the backend isn't enabled at all, early out
             except NoBackendEnabled:
                 break
@@ -69,10 +65,6 @@ class BaseTransformerProcessorMixin:
 
         try:
             transformed_event = self.get_transformed_event(event)
-
-        except NoBackendEnabled:
-            return None
-
         except NoTransformerImplemented:
             logger.error('Could not get transformer for %s event.', event_name)
             return None

--- a/event_routing_backends/processors/xapi/tests/test_xapi.py
+++ b/event_routing_backends/processors/xapi/tests/test_xapi.py
@@ -5,7 +5,6 @@ import uuid
 
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from eventtracking.processors.exceptions import EventEmissionExit, NoBackendEnabled
 from mock import MagicMock, call, patch, sentinel
 from tincan import Activity, Statement
 

--- a/event_routing_backends/processors/xapi/tests/test_xapi.py
+++ b/event_routing_backends/processors/xapi/tests/test_xapi.py
@@ -25,13 +25,11 @@ class TestXApiProcessor(SimpleTestCase):
 
     @override_settings(XAPI_EVENTS_ENABLED=False)
     def test_skip_event_when_disabled(self):
-        with self.assertRaises(NoBackendEnabled):
-            self.processor(self.sample_event)
+        self.assertFalse(self.processor(self.sample_event))
 
     @patch('event_routing_backends.processors.mixins.base_transformer_processor.logger')
     def test_send_method_with_no_transformer_implemented(self, mocked_logger):
-        with self.assertRaises(EventEmissionExit):
-            self.processor([self.sample_event])
+        self.assertFalse(self.processor([self.sample_event]))
 
         mocked_logger.error.assert_called_once_with(
             'Could not get transformer for %s event.',
@@ -91,9 +89,7 @@ class TestXApiProcessor(SimpleTestCase):
         mocked_transformer.transform.return_value = transformed_event
         mocked_get_transformer.return_value = mocked_transformer
 
-        with self.assertRaises(EventEmissionExit):
-            self.processor([self.sample_event])
-
+        self.assertFalse(self.processor([self.sample_event]))
         self.assertNotIn(call(transformed_event.to_json()), mocked_logger.mock_calls)
 
     @override_settings(XAPI_EVENT_LOGGING_ENABLED=False)
@@ -116,6 +112,5 @@ class TestXApiProcessor(SimpleTestCase):
     def test_with_no_registry(self, mocked_logger):
         backend = XApiProcessor()
         backend.registry = None
-        with self.assertRaises(EventEmissionExit):
-            self.assertIsNone(backend([self.sample_event]))
+        self.assertFalse(backend([self.sample_event]))
         mocked_logger.exception.assert_called_once()


### PR DESCRIPTION
When errors such as when a backend isn't configured or there is no transformer for an event, bubbles up it causes the whole batch to get dumped to the dead letter queue. These changes cause those errors to be logged but otherwise just get dropped from the batch.

Error:
```
[2024-03-27 14:58:10,291: INFO/ForkPoolWorker-23] Event edx.course.enrollment.deactivated has been queued for batching. Queue size: 10
[2024-03-27 14:58:10,291: INFO/MainProcess] Task event_routing_backends.tasks.dispatch_bulk_events[c6ff920d-3d73-410d-ab73-bd41cfae0ec1] received
[2024-03-27 14:58:10,292: ERROR/ForkPoolWorker-23] Exception occurred while trying to bulk dispatch 10 events.
Traceback (most recent call last):
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/backends/events_router.py", line 187, in send
    self.bulk_send([json.loads(queued_event.decode('utf-8')) for queued_event in batch])
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/backends/events_router.py", line 153, in bulk_send
    event_routes = self.prepare_to_send(events)
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/backends/events_router.py", line 93, in prepare_to_send
    processed_events = self.process_event(event)
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/backends/events_router.py", line 256, in process_event
    events = processor(events)
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/processors/mixins/base_transformer_processor.py", line 37, in __call__
    transformed_event = self.transform_event(event)
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/processors/caliper/transformer_processor.py", line 43, in transform_event
    raise NoBackendEnabled
eventtracking.processors.exceptions.NoBackendEnabled
[2024-03-27 14:58:10,292: INFO/ForkPoolWorker-23] Pushing failed events to the dead queue: dead_queue_caliper
```