### PR TITLE
feat!: use one configuration for all backends

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[9.0.0]
+~~~~~~~
+
+* **BREAKING CHANGE**: Use a single entry point for all event routing backends.
+  which allows to easily switch bettwen celery and the event bus for the backends.
+
 [8.3.0]
 
 * Allow to use any configured engine to replay tracking logs

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '8.3.1'
+__version__ = '9.0.0'

--- a/event_routing_backends/backends/events_router.py
+++ b/event_routing_backends/backends/events_router.py
@@ -219,7 +219,8 @@ class EventsRouter:
         Queue the event to be sent to configured routers.
 
         """
-        event["timestamp"] = event["timestamp"].isoformat()
+        if isinstance(event["timestamp"], datetime):
+            event["timestamp"] = event["timestamp"].isoformat()
         queue_size = redis.lpush(self.queue_name, json.dumps(event, cls=DateTimeJSONEncoder))
         logger.info(f'Event {event["name"]} has been queued for batching. Queue size: {queue_size}')
 

--- a/event_routing_backends/backends/tests/test_events_router.py
+++ b/event_routing_backends/backends/tests/test_events_router.py
@@ -275,13 +275,16 @@ class TestEventsRouter(TestCase):
         event1 = copy(self.transformed_event)
         event1["timestamp"] = datetime.datetime.now()
         event2 = copy(self.transformed_event)
-        event2["timestamp"] = datetime.datetime.now()
+        event2_emission = datetime.datetime.now()
+        event2["timestamp"] = event2_emission
         events = [event1, event2]
         formatted_events = []
         for event in events:
             formatted_event = copy(event)
-            formatted_event["timestamp"] = formatted_event["timestamp"].isoformat()
+            formatted_event["timestamp"] = event["timestamp"].isoformat()
             formatted_events.append(json.dumps(formatted_event).encode('utf-8'))
+
+        event2["timestamp"] = event2_emission.isoformat()
 
         redis_mock.rpop.return_value = formatted_events
         redis_mock.lpush.return_value = 1

--- a/event_routing_backends/management/commands/helpers/queued_sender.py
+++ b/event_routing_backends/management/commands/helpers/queued_sender.py
@@ -42,7 +42,8 @@ class QueuedSender:
         self.batches_sent = 0
 
         self.tracker = get_tracker()
-        self.engine = self.tracker.backends[self.transformer_type]
+        self.engine = self.tracker.backends["event_transformer"]
+        self.backend = self.engine.backends[self.transformer_type]
 
     def is_known_event(self, event):
         """
@@ -98,8 +99,7 @@ class QueuedSender:
         """
         if self.destination == "LRS":
             print(f"Sending {len(self.event_queue)} events to LRS...")
-            for backend in self.engine.backends.values():
-                backend.bulk_send(self.event_queue)
+            self.backend.bulk_send(self.event_queue)
         else:
             print("Skipping send, we're storing with libcloud instead of an LRS.")
 

--- a/event_routing_backends/management/commands/tests/test_transform_tracking_logs.py
+++ b/event_routing_backends/management/commands/tests/test_transform_tracking_logs.py
@@ -211,8 +211,8 @@ def test_transform_command(command_opts, mock_common_calls, caplog, capsys):
     mm2.registry.mapping = {"problem_check": 1}
     # Fake a process response that can be serialized to json
     mm2.return_value = {"foo": "bar"}
-    tracker.backends["xapi"].processors = [mm2]
-    for backend in tracker.backends["xapi"].backends.values():
+    tracker.backends["event_transformer"].processors = [mm2]
+    for backend in tracker.backends["event_transformer"].backends.values():
         backend.bulk_send = MagicMock()
 
     call_command(

--- a/event_routing_backends/tests/test_settings.py
+++ b/event_routing_backends/tests/test_settings.py
@@ -20,8 +20,9 @@ class TestPluginSettings(TestCase):
         Test common settings
         """
         common_settings.plugin_settings(settings)
-        self.assertIn('xapi', settings.EVENT_TRACKING_BACKENDS)
-        self.assertIn('caliper', settings.EVENT_TRACKING_BACKENDS)
+        self.assertIn('event_transformer', settings.EVENT_TRACKING_BACKENDS)
+        self.assertIn('xapi', settings.EVENT_TRACKING_BACKENDS["event_transformer"]["OPTIONS"]["backends"])
+        self.assertIn('caliper', settings.EVENT_TRACKING_BACKENDS["event_transformer"]["OPTIONS"]["backends"])
         self.assertIn('edx.course.enrollment.activated', settings.EVENT_TRACKING_BACKENDS_BUSINESS_CRITICAL_EVENTS)
         self.assertFalse(settings.CALIPER_EVENTS_ENABLED)
         self.assertFalse(settings.CALIPER_EVENT_LOGGING_ENABLED)
@@ -33,8 +34,9 @@ class TestPluginSettings(TestCase):
         Test devstack settings
         """
         devstack_settings.plugin_settings(settings)
-        self.assertIn('xapi', settings.EVENT_TRACKING_BACKENDS)
-        self.assertIn('caliper', settings.EVENT_TRACKING_BACKENDS)
+        self.assertIn('event_transformer', settings.EVENT_TRACKING_BACKENDS)
+        self.assertIn('xapi', settings.EVENT_TRACKING_BACKENDS["event_transformer"]["OPTIONS"]["backends"])
+        self.assertIn('caliper', settings.EVENT_TRACKING_BACKENDS["event_transformer"]["OPTIONS"]["backends"])
         self.assertIn('edx.course.enrollment.deactivated', settings.EVENT_TRACKING_BACKENDS_BUSINESS_CRITICAL_EVENTS)
         self.assertFalse(settings.CALIPER_EVENTS_ENABLED)
         self.assertFalse(settings.CALIPER_EVENT_LOGGING_ENABLED)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -104,7 +104,7 @@ edx-toggles==5.1.1
     # via
     #   -r requirements/base.in
     #   event-tracking
-event-tracking==2.3.1
+event-tracking==2.3.2
     # via -r requirements/base.in
 fastavro==1.9.4
     # via openedx-events

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,3 +23,4 @@ sphinx==4.2.0
 # This pin can be removed once sphinx constraint is removed.
 docutils<0.18
 doc8<1.0.0
+event-tracking>=2.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -198,7 +198,7 @@ edx-toggles==5.1.1
     # via
     #   -r requirements/quality.txt
     #   event-tracking
-event-tracking==2.3.1
+event-tracking==2.3.2
     # via -r requirements/quality.txt
 exceptiongroup==1.2.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -174,7 +174,7 @@ edx-toggles==5.1.1
     # via
     #   -r requirements/test.txt
     #   event-tracking
-event-tracking==2.3.1
+event-tracking==2.3.2
     # via -r requirements/test.txt
 exceptiongroup==1.2.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -162,7 +162,7 @@ edx-toggles==5.1.1
     # via
     #   -r requirements/test.txt
     #   event-tracking
-event-tracking==2.3.1
+event-tracking==2.3.2
     # via -r requirements/test.txt
 exceptiongroup==1.2.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -147,7 +147,7 @@ edx-toggles==5.1.1
     # via
     #   -r requirements/base.txt
     #   event-tracking
-event-tracking==2.3.1
+event-tracking==2.3.2
     # via -r requirements/base.txt
 exceptiongroup==1.2.0
     # via pytest

--- a/test_settings.py
+++ b/test_settings.py
@@ -51,7 +51,7 @@ EVENT_ROUTING_BACKEND_BATCHING_ENABLED = False
 EVENT_ROUTING_BACKEND_BATCH_INTERVAL = 100
 EVENT_TRACKING_ENABLED = True
 EVENT_TRACKING_BACKENDS = {
-    "xapi": {
+    "event_transformer": {
         "ENGINE": "eventtracking.backends.async_routing.AsyncRoutingBackend",
         "OPTIONS": {
             "backends": {
@@ -67,13 +67,6 @@ EVENT_TRACKING_BACKENDS = {
                         "backend_name": "xapi",
                     },
                 },
-            },
-        },
-    },
-    "caliper": {
-        "ENGINE": "eventtracking.backends.async_routing.AsyncRoutingBackend",
-        "OPTIONS": {
-            "backends": {
                 "caliper": {
                     "ENGINE": "event_routing_backends.backends.async_events_router.AsyncEventsRouter",
                     "OPTIONS": {
@@ -87,7 +80,7 @@ EVENT_TRACKING_BACKENDS = {
                         "backend_name": "caliper",
                     },
                 },
-            }
+            },
         },
     },
 }


### PR DESCRIPTION
**Description:** This PR updates the configuration to only use 1 setting entry for both backends.

This is a proposal, and depends on: https://github.com/openedx/event-tracking/pull/273