### PR TITLE
fix: use whitelisted events to identify known_events

### DIFF
--- a/event_routing_backends/management/commands/helpers/queued_sender.py
+++ b/event_routing_backends/management/commands/helpers/queued_sender.py
@@ -51,7 +51,7 @@ class QueuedSender:
         """
         if "name" in event:
             for processor in self.engine.processors:
-                if event["name"] in processor.registry.mapping:
+                if event["name"] in processor.whitelist:
                     return True
         return False
 


### PR DESCRIPTION
**Description:** This PR fixes a bug introduced by the new setting structure:

```shell
Traceback (most recent call last):
  File "./manage.py", line 106, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/openedx/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/openedx/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/openedx/venv/lib/python3.8/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/openedx/venv/lib/python3.8/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/management/commands/transform_tracking_logs.py", line 299, in handle
    transform_tracking_logs(
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/management/commands/transform_tracking_logs.py", line 92, in transform_tracking_logs
    sender.transform_and_queue(line)
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/management/commands/helpers/queued_sender.py", line 68, in transform_and_queue
    if not self.is_known_event(event):
  File "/openedx/venv/lib/python3.8/site-packages/event_routing_backends/management/commands/helpers/queued_sender.py", line 54, in is_known_event
    if event["name"] in processor.registry.mapping:
AttributeError: 'NameWhitelistProcessor' object has no attribute 'registry'
```


**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** This may not be the right fix to apply, we should probably send all events to the transformers and let trigger an error.
