### PR TITLE
fix: Add support for whitelist and legacy registry options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[9.2.1]
+
+* Add support for either 'whitelist' or 'registry.mapping' options (whitelist introduced in v9.0.0)
 
 [9.2.0]
 

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '9.2.0'
+__version__ = '9.2.1'

--- a/event_routing_backends/management/commands/helpers/queued_sender.py
+++ b/event_routing_backends/management/commands/helpers/queued_sender.py
@@ -51,7 +51,9 @@ class QueuedSender:
         """
         if "name" in event:
             for processor in self.engine.processors:
-                if event["name"] in processor.registry.mapping:
+                if hasattr(processor, 'whitelist') and event["name"] in processor.whitelist:
+                    return True
+                elif hasattr(processor, 'registry') and event["name"] in processor.registry.mapping:
                     return True
         return False
 

--- a/event_routing_backends/management/commands/tests/test_transform_tracking_logs.py
+++ b/event_routing_backends/management/commands/tests/test_transform_tracking_logs.py
@@ -76,6 +76,7 @@ def command_options():
                     "Sending to LRS!"
                 ]
             },
+            "registry_mapping": {"problem_check": 1},
         },
         # Remote file to LRS dry run no batch size
         {
@@ -94,6 +95,7 @@ def command_options():
                     "Queued 2 log lines, could not parse 2 log lines, skipped 8 log lines, sent 0 batches.",
                 ]
             },
+            "registry_mapping": {"problem_check": 1},
         },
         # Remote file to LRS, default batch size
         {
@@ -112,6 +114,7 @@ def command_options():
                     "Queued 2 log lines, could not parse 2 log lines, skipped 8 log lines, sent 1 batches.",
                 ]
             },
+            "whitelist": ["problem_check"]
         },
         # Local file to remote file
         {
@@ -135,6 +138,7 @@ def command_options():
                     "Queued 2 log lines, could not parse 2 log lines, skipped 8 log lines, sent 2 batches.",
                 ]
             },
+            "whitelist": ["problem_check"]
         },
         # Remote file dry run
         {
@@ -157,6 +161,7 @@ def command_options():
                     "Queued 2 log lines, could not parse 2 log lines, skipped 8 log lines, sent 0 batches.",
                 ]
             },
+            "whitelist": ["problem_check"]
         },
     ]
 
@@ -208,7 +213,12 @@ def test_transform_command(command_opts, mock_common_calls, caplog, capsys):
 
     mm2 = MagicMock()
     # Fake a router mapping so some events in the log are actually processed
-    mm2.registry.mapping = {"problem_check": 1}
+    import logging
+    logger = logging.getLogger()
+    if command_opts.get("registry_mapping"):
+        mm2.registry.mapping = command_opts.pop("registry_mapping")
+    if command_opts.get("whitelist"):
+        mm2.whitelist = command_opts.pop("whitelist")
     # Fake a process response that can be serialized to json
     mm2.return_value = {"foo": "bar"}
     tracker.backends["event_transformer"].processors = [mm2]

--- a/event_routing_backends/management/commands/tests/test_transform_tracking_logs.py
+++ b/event_routing_backends/management/commands/tests/test_transform_tracking_logs.py
@@ -213,8 +213,6 @@ def test_transform_command(command_opts, mock_common_calls, caplog, capsys):
 
     mm2 = MagicMock()
     # Fake a router mapping so some events in the log are actually processed
-    import logging
-    logger = logging.getLogger()
     if command_opts.get("registry_mapping"):
         mm2.registry.mapping = command_opts.pop("registry_mapping")
     if command_opts.get("whitelist"):


### PR DESCRIPTION
**Description:** Check 'whitelist' and 'registry.mapping' options for event names to process. 'whitelist' was introduced in v9.0.0 but the tests and event check were not updated.


**Testing instructions:**
Tested all unit tests
Tested with (https://github.com/openedx/event-routing-backends/blob/84e09bc5fa7dde9ee2ed07fc04721c0799ad34e0/docs/howto/how_to_bulk_transform.rst#examples)
- LOCAL xapi
- LOCAL caliper
- MINIO

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
