### PR TITLE
fix: event-tracking:2.4.1 clutter with openedx:master

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,6 +23,8 @@ sphinx==4.2.0
 # This pin can be removed once sphinx constraint is removed.
 docutils<0.18
 doc8<1.0.0
-event-tracking>=2.3.2
+# event-tracking has a breaking change at 2.4.1 version so openedx master release can't connect to mongo.
+# see https://github.com/openedx/tutor-contrib-aspects/issues/891
+event-tracking>=2.3.2,<2.4.1
 # it is not availablein python3.9
 backports.zoneinfo;python_version<"3.9"


### PR DESCRIPTION
**Description:** `event-tracking` one of this package dependencies, created a new version (https://github.com/openedx/event-tracking/pull/290) which upgraded the `PyMongo` version. So when we install this package in the old style, we will get the latest event-tracking version with `PyMongo` 4.4.0 which is incompatible with openedx master.
I've created this PR in response to a `tutor-contrib-aspects` issue

**Dependencies:** See the aspects [issue](https://github.com/openedx/tutor-contrib-aspects/issues/891)

