### PR TITLE
perf: add lru cache for users and courses

### DIFF
--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -4,9 +4,9 @@ Helper utilities for event transformers.
 import datetime
 import logging
 import uuid
+from functools import lru_cache
 from urllib.parse import parse_qs, urlparse
 
-from functools import lru_cache
 from dateutil.parser import parse
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -52,6 +52,7 @@ def get_uuid5(namespace_key, name):
     base_namespace = uuid.uuid5(base_uuid, namespace_key)
     return uuid.uuid5(base_namespace, name)
 
+
 @lru_cache
 def get_anonymous_user_id(username_or_id, external_type):
     """
@@ -95,6 +96,7 @@ def get_anonymous_user_id(username_or_id, external_type):
     anonymous_id = str(external_id.external_user_id)
 
     return anonymous_id
+
 
 def get_user(username_or_id):
     """
@@ -148,6 +150,7 @@ def get_user_email(username_or_id):
         user_email = user.email
 
     return user_email
+
 
 @lru_cache
 def get_course_from_id(course_id):

--- a/event_routing_backends/helpers.py
+++ b/event_routing_backends/helpers.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from urllib.parse import parse_qs, urlparse
 
+from functools import lru_cache
 from dateutil.parser import parse
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -51,7 +52,7 @@ def get_uuid5(namespace_key, name):
     base_namespace = uuid.uuid5(base_uuid, namespace_key)
     return uuid.uuid5(base_namespace, name)
 
-
+@lru_cache
 def get_anonymous_user_id(username_or_id, external_type):
     """
     Generate anonymous user id.
@@ -94,7 +95,6 @@ def get_anonymous_user_id(username_or_id, external_type):
     anonymous_id = str(external_id.external_user_id)
 
     return anonymous_id
-
 
 def get_user(username_or_id):
     """
@@ -149,7 +149,7 @@ def get_user_email(username_or_id):
 
     return user_email
 
-
+@lru_cache
 def get_course_from_id(course_id):
     """
     Get Course object using the `course_id`.

--- a/event_routing_backends/tests/test_helpers.py
+++ b/event_routing_backends/tests/test_helpers.py
@@ -53,7 +53,7 @@ class TestHelpers(TestCase):
         mocked_external_id.add_new_user_id.return_value = (None, False)
         # Test that a failure to add an external id raises an error
         with self.assertRaises(ValueError):
-            get_anonymous_user_id('edx', 'XAPI')
+            get_anonymous_user_id('edx2', 'XAPI')
 
         # Test that an unknown user raises this error
         with self.assertRaises(ValueError):


### PR DESCRIPTION
**Description:** Add the `lru_cache` decorator to the `get_anonymous_userid` and `get_course_overview` methods. Increased throughput up to 8 times on the `transform_tracking_log` command.

Closes #354 

```
Queued 16254 log lines, could not parse 0 log lines, skipped 1109 log lines, sent 1 batches.
         60359691 function calls (55756047 primitive calls) in 98.828 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   6472/1    0.096    0.000   98.958   98.958 {built-in method builtins.exec}
        1    0.000    0.000   98.958   98.958 manage.py:1(<module>)
        1    0.000    0.000   90.905   90.905 __init__.py:439(execute_from_command_line)
        1    0.000    0.000   90.904   90.904 __init__.py:353(execute)
        1    0.000    0.000   90.844   90.844 base.py:395(run_from_argv)
        1    0.022    0.022   90.841   90.841 base.py:431(execute)
        1    0.004    0.004   87.433   87.433 transform_tracking_logs.py:270(handle)
        1    3.800    3.800   87.398   87.398 transform_tracking_logs.py:55(transform_tracking_logs)
        1    0.000    0.000   82.565   82.565 queued_sender.py:140(finalize)
        1    0.062    0.062   82.565   82.565 queued_sender.py:96(send)
        1    0.050    0.050   82.502   82.502 events_router.py:142(bulk_send)
        1    0.284    0.284   53.182   53.182 events_router.py:67(prepare_to_send)
    16254    0.111    0.000   52.427    0.003 events_router.py:261(process_event)
    16254    0.174    0.000   52.205    0.003 base_transformer_processor.py:21(__call__)
    16254    0.335    0.000   52.026    0.003 transformer_processor.py:29(transform_event)
    16254    0.043    0.000   38.199    0.002 base_transformer_processor.py:51(transform_event)
    16254    0.071    0.000   38.127    0.002 base_transformer_processor.py:85(get_transformed_event)
    16254    0.122    0.000   37.952    0.002 transformer.py:36(transform)
    16254    0.196    0.000   32.492    0.002 base_transformer.py:92(transform)
        1    0.000    0.000   29.261   29.261 async_events_router.py:28(dispatch_bulk_events)
        1    0.035    0.035   29.261   29.261 task.py:433(delay)
        1    0.000    0.000   29.226   29.226 task.py:446(apply_async)
        1    0.000    0.000   27.436   27.436 task.py:760(apply)
        1    0.002    0.002   27.429   27.429 trace.py:386(trace_task)
        1    0.000    0.000   27.128   27.128 tasks.py:95(dispatch_bulk_events)
        1    0.054    0.054   27.128   27.128 tasks.py:109(bulk_send_events)
        1    0.000    0.000   27.073   27.073 xapi_lrs_client.py:63(bulk_send)
        1    0.009    0.009   27.073   27.073 remote_lrs.py:212(save_statements)
    16254    0.141    0.000   26.925    0.002 transformer.py:51(base_transform)
81597/81235    0.384    0.000   22.924    0.000 decorators.py:39(inner_wrapper)
395457/197043    2.397    0.000   21.957    0.000 serializable_base.py:54(__init__)
4789691/2099441    8.737    0.000   21.578    0.000 base.py:48(__setattr__)
379179/196967    1.775    0.000   20.562    0.000 base.py:27(__init__)
1313691/847393    0.850    0.000   19.135    0.000 {built-in method builtins.setattr}
    16254    0.148    0.000   18.778    0.001 transformer.py:64(get_event_id)
    32486    0.175    0.000   15.777    0.000 statement.py:59(__init__)
    32486    0.162    0.000   15.277    0.000 statement_base.py:50(__init__)
    32500    0.315    0.000   14.932    0.000 transformer.py:82(get_actor)
    48736    0.233    0.000   14.256    0.000 serializable_base.py:92(to_json)
     1048    0.023    0.000   12.881    0.012 __init__.py:1(<module>)
549765/48736    6.586    0.000   12.218    0.000 serializable_base.py:108(as_version)
        1    0.000    0.000   11.123   11.123 remote_lrs.py:91(_send_request)
        6    0.000    0.000   11.114    1.852 client.py:1346(getresponse)
        6    0.000    0.000   11.114    1.852 client.py:318(begin)
       17    0.000    0.000   11.113    0.654 socket.py:692(readinto)
       17   11.113    0.654   11.113    0.654 {method 'recv_into' of '_socket.socket' objects}
```

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
