### PR TITLE
fix: send chunk_size instead of manually handling it

### DIFF
--- a/event_routing_backends/management/commands/transform_tracking_logs.py
+++ b/event_routing_backends/management/commands/transform_tracking_logs.py
@@ -11,14 +11,13 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from libcloud.storage.providers import get_driver
 from libcloud.storage.types import Provider
-
 from event_routing_backends.management.commands.helpers.queued_sender import QueuedSender
 
 # Number of bytes to download at a time, this is 2 MB
 CHUNK_SIZE = 1024 * 1024 * 2
 
 
-def _get_chunks(source, file, start_byte, end_byte):
+def _get_chunks(source, file):
     """
     Fetch a chunk from the upstream source, retry 3 times if necessary.
 
@@ -35,8 +34,8 @@ def _get_chunks(source, file, start_byte, end_byte):
         try:
             chunks = source.download_object_range_as_stream(
                 file,
-                start_bytes=start_byte,
-                end_bytes=end_byte
+                start_bytes=0,
+                chunk_size=CHUNK_SIZE
             )
             break
         # Catching all exceptions here because there's no telling what all
@@ -72,29 +71,22 @@ def transform_tracking_logs(
         # Download the file as a stream of characters to save on memory
         print(f"Streaming file {file}...")
 
-        last_successful_byte = 0
         line = ""
 
-        while last_successful_byte < int(file.size):
-            end_byte = last_successful_byte + CHUNK_SIZE
+        chunks = _get_chunks(source, file)
 
-            end_byte = min(end_byte, file.size)
+        for chunk in chunks:
+            chunk = chunk.decode('utf-8')
 
-            chunks = _get_chunks(source, file, last_successful_byte, end_byte)
+            # Loop through this chunk, if we find a newline it's time to process
+            # otherwise just keep appending.
+            for char in chunk:
+                if char == "\n" and line:
+                    sender.transform_and_queue(line)
+                    line = ""
+                else:
+                    line += char
 
-            for chunk in chunks:
-                chunk = chunk.decode('utf-8')
-
-                # Loop through this chunk, if we find a newline it's time to process
-                # otherwise just keep appending.
-                for char in chunk:
-                    if char == "\n" and line:
-                        sender.transform_and_queue(line)
-                        line = ""
-                    else:
-                        line += char
-
-            last_successful_byte = end_byte
         # Sometimes the file doesn't end with a newline, we try to use
         # any remaining bytes as a final line.
         if line:

--- a/event_routing_backends/management/commands/transform_tracking_logs.py
+++ b/event_routing_backends/management/commands/transform_tracking_logs.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from libcloud.storage.providers import get_driver
 from libcloud.storage.types import Provider
+
 from event_routing_backends.management.commands.helpers.queued_sender import QueuedSender
 
 # Number of bytes to download at a time, this is 2 MB


### PR DESCRIPTION
**Description:** Sned the `chunk_size` parameter to libcloud directly instead of manually handling it, avoiding errors such as `ContentDecodeError` and `UnicodeDecodeError` on gzip files. Closes: #457 

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
