### PR TITLE
feat: add --lrs-urls option to transform_tracking_logs command

### DIFF
--- a/docs/howto/how_to_bulk_transform.rst
+++ b/docs/howto/how_to_bulk_transform.rst
@@ -35,7 +35,7 @@ Modes Of Operation
 
 The command can work in a few distinct ways.
 
-**File(s) to learning record store (LRS)** - this will use the existing event-routing-backends configuration to route any log replays to **all** configured LRS backends just like the event was being emitted right now. This can be used to backfill old data, capture old events that didn't previously have transforms, or fix up lost data from downtime issues.
+**File(s) to learning record store (LRS)** - this will use the existing event-routing-backends configuration to route any log replays to **all** configured LRS backends by default, just like the event was being emitted right now. This can be used to backfill old data, capture old events that didn't previously have transforms, or fix up lost data from downtime issues. To target specific LRSs, you can use the ``--lrs-urls`` option to specify one or more LRS endpoints by their `route_url`. When provided, the command will route the transformed events exclusively to the specified LRSs, rather than all configured ones.
 
 **File(s) to file(s)** - This will perform the same transformations as usual, but instead of routing them to an LRS they can be saved as a file to any libcloud destination. In this mode all events are saved to a single file and no filters are applied.
 
@@ -64,6 +64,16 @@ Examples
     --source_config '{"key": "/openedx/data/", "prefix": "tracking.log", "container": "logs"}' \
     --destination_provider LRS \
     --transformer_type xapi
+
+::
+
+    # Transform all events in the local file /openedx/data/tracking.log to the specified LRSs
+    python manage.py lms transform_tracking_logs \
+    --source_provider LOCAL \
+    --source_config '{"key": "/openedx/data/", "prefix": "tracking.log", "container": "logs"}' \
+    --destination_provider LRS \
+    --transformer_type xapi \
+    --lrs-urls http://lrs1.example.com http://lrs2.example.com
 
 ::
 

--- a/event_routing_backends/backends/events_router.py
+++ b/event_routing_backends/backends/events_router.py
@@ -64,11 +64,15 @@ class EventsRouter:
 
         return host
 
-    def prepare_to_send(self, events):
+    def prepare_to_send(self, events, router_urls=None):
         """
         Prepare a list of events to be sent and create a processed, filtered batch for each router.
+        If router_urls are explicitly mentioned, then only use the specified routers
         """
         routers = RouterConfiguration.get_enabled_routers(self.backend_name)
+        if router_urls:
+            routers = routers.filter(route_url__in=router_urls)
+
         business_critical_events = get_business_critical_events()
         route_events = {}
 
@@ -139,7 +143,7 @@ class EventsRouter:
             return []
         return [json.loads(event.decode('utf-8')) for event in failed_events]
 
-    def bulk_send(self, events):
+    def bulk_send(self, events, router_urls=None):
         """
         Send the event to configured routers after processing it.
 
@@ -150,7 +154,7 @@ class EventsRouter:
         Arguments:
             events (list[dict]): list of original event dictionaries
         """
-        event_routes = self.prepare_to_send(events)
+        event_routes = self.prepare_to_send(events, router_urls)
 
         for events_for_route in event_routes.values():
             prepared_events = []

--- a/event_routing_backends/management/commands/helpers/queued_sender.py
+++ b/event_routing_backends/management/commands/helpers/queued_sender.py
@@ -24,7 +24,8 @@ class QueuedSender:
         transformer_type,
         max_queue_size=10000,
         sleep_between_batches_secs=1.0,
-        dry_run=False
+        dry_run=False,
+        lrs_urls=None
     ):
         self.destination = destination
         self.destination_container = destination_container
@@ -34,6 +35,7 @@ class QueuedSender:
         self.max_queue_size = max_queue_size
         self.sleep_between_batches = sleep_between_batches_secs
         self.dry_run = dry_run
+        self.lrs_urls = lrs_urls or []
 
         # Bookkeeping
         self.queued_lines = 0
@@ -101,7 +103,7 @@ class QueuedSender:
         """
         if self.destination == "LRS":
             print(f"Sending {len(self.event_queue)} events to LRS...")
-            self.backend.bulk_send(self.event_queue)
+            self.backend.bulk_send(self.event_queue, self.lrs_urls)
         else:
             print("Skipping send, we're storing with libcloud instead of an LRS.")
 


### PR DESCRIPTION
Introduced the --lrs-urls argument to allow specifying multiple LRS route URLs. This enhancement enables sending tracking logs exclusively to the designated LRSs, preventing data from being sent to all configured LRSs.

close #483

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
