### PR TITLE
fix: keep unicode characters in problem response list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[9.3.3]
+
+* Fixes bad decoding of unicode characrters during json dumps
+
 [9.3.2]
 
 * Fixes issues with gzip files and duplicated events

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '9.3.2'
+__version__ = '9.3.3'

--- a/event_routing_backends/processors/tests/fixtures/current/problem_check(server).list_answers.json
+++ b/event_routing_backends/processors/tests/fixtures/current/problem_check(server).list_answers.json
@@ -147,10 +147,10 @@
       "a0effb954cca4759994f1ac9e9434bf4_5_1": {
         "question": "",
         "answer": [
-          "Un emprunt \u00e0 l'anglais ou anglicisme",
+          "Un emprunt à l'anglais ou anglicisme",
           "Un type de demande",
-          "Quelque chose de rapide, d'instantan\u00e9",
-          "Une question structur\u00e9e et pr\u00e9cise",
+          "Quelque chose de rapide, d'instantané",
+          "Une question structuré et précise",
           "Un type de poisson",
           "I\"M SWP' \"SDF\""
         ],

--- a/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
@@ -509,4 +509,4 @@ class JSONEncodedResult(Result):
         if not isinstance(value, list):
             raise ValueError(f"JSONEncodedResult only accepts lists, {type(value)} given.")
 
-        self._response = json.dumps(value)
+        self._response = json.dumps(value, ensure_ascii=False)

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).list_answers.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).list_answers.json
@@ -131,7 +131,7 @@
     "id": "707a78e0-c017-5a78-9581-df5bcca031c9",
     "result": {
       "success": false,
-      "response": "[\"Un emprunt \\u00e0 l'anglais ou anglicisme\", \"Un type de demande\", \"Quelque chose de rapide, d'instantan\\u00e9\", \"Une question structur\\u00e9e et pr\\u00e9cise\", \"Un type de poisson\", \"I\\\"M SWP' \\\"SDF\\\"\"]"
+      "response": "[\"Un emprunt à l'anglais ou anglicisme\", \"Un type de demande\", \"Quelque chose de rapide, d'instantané\", \"Une question structuré et précise\", \"Un type de poisson\", \"I\\\"M SWP' \\\"SDF\\\"\"]"
     },
     "version": "1.0.3",
     "actor": {


### PR DESCRIPTION
**Description:** Describe in a couple of sentences what this PR adds
Maintain unicode characters in multi select problems during json dumps to match non-list responses

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Create a multi-select problem with answers that have unicode characters (è, á)
2. Submit response to the problem
3. Check xapi.problem_events , column `responses` and ensure unicode is still formatted correctly in the array

Current:
["Clart\u00e9", "Coh\u00e9rence", "Longueur"]
New:
["Clarté", "Cohérence", "Longueur"]


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
