### PR TITLE
fix: Change search order for users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[9.3.6]
+
+* Fixes issues where the context user is not the same as the data user, such as enrolling uses via the Instructor Dashboard
+
 [9.3.5]
 
 * Adding django52 support.

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,4 +2,4 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '9.3.5'
+__version__ = "9.3.6"

--- a/event_routing_backends/models.py
+++ b/event_routing_backends/models.py
@@ -1,7 +1,7 @@
-
 """
 Database models for event_routing_backends.
 """
+
 import logging
 import re
 
@@ -39,7 +39,7 @@ def get_value_from_dotted_path(dict_obj, dotted_key):
         ANY :                 Returns the value found in the dict or `None` if
                               no value exists for provided dotted path.
     """
-    nested_keys = dotted_key.split('.')
+    nested_keys = dotted_key.split(".")
     result = dict_obj
     try:
         for key in nested_keys:
@@ -64,12 +64,18 @@ class RouterConfigurationManager(ConfigurationModelManager):
         if not backend_name:
             return []
 
-        cache_key = get_cache_key(namespace="event_routing_backends", resource=backend_name)
+        cache_key = get_cache_key(
+            namespace="event_routing_backends", resource=backend_name
+        )
         cached_response = TieredCache.get_cached_response(cache_key)
         if cached_response.is_found:
             return cached_response.value
 
-        current = self.current_set().filter(backend_name=backend_name, enabled=True).order_by('-change_date')
+        current = (
+            self.current_set()
+            .filter(backend_name=backend_name, enabled=True)
+            .order_by("-change_date")
+        )
         TieredCache.set_all_tiers(cache_key, current, backend_cache_ttl())
         return current
 
@@ -114,13 +120,19 @@ class RouterConfiguration(ConfigurationModel):
 
     """
 
-    AUTH_BASIC = 'Basic'
-    AUTH_BEARER = 'Bearer'
-    AUTH_CHOICES = ((AUTH_BASIC, 'Basic'), (AUTH_BEARER, 'Bearer'),)
-    CALIPER_BACKEND = 'Caliper'
-    XAPI_BACKEND = 'xAPI'
-    BACKEND_CHOICES = ((CALIPER_BACKEND, 'Caliper'), (XAPI_BACKEND, 'xAPI'),)
-    KEY_FIELDS = ('route_url',)
+    AUTH_BASIC = "Basic"
+    AUTH_BEARER = "Bearer"
+    AUTH_CHOICES = (
+        (AUTH_BASIC, "Basic"),
+        (AUTH_BEARER, "Bearer"),
+    )
+    CALIPER_BACKEND = "Caliper"
+    XAPI_BACKEND = "xAPI"
+    BACKEND_CHOICES = (
+        (CALIPER_BACKEND, "Caliper"),
+        (XAPI_BACKEND, "xAPI"),
+    )
+    KEY_FIELDS = ("route_url",)
     backend_name = models.CharField(
         choices=BACKEND_CHOICES,
         max_length=50,
@@ -129,49 +141,40 @@ class RouterConfiguration(ConfigurationModel):
         db_index=True,
         default=XAPI_BACKEND,
         help_text=(
-            'Name of the tracking backend on which this router should be applied.'
-            '<br/>'
-            'Please note that this field is <b>case sensitive.</b>'
-        )
+            "Name of the tracking backend on which this router should be applied."
+            "<br/>"
+            "Please note that this field is <b>case sensitive.</b>"
+        ),
     )
 
     route_url = models.CharField(
         max_length=255,
-        verbose_name='Route url',
+        verbose_name="Route url",
         null=False,
         blank=False,
         help_text=(
-            'Route Url of the tracking backend on which this router should be applied.'
-            '<br/>'
-            'Please note that this field is <b>case sensitive.</b>'
-        )
+            "Route Url of the tracking backend on which this router should be applied."
+            "<br/>"
+            "Please note that this field is <b>case sensitive.</b>"
+        ),
     )
 
     auth_scheme = models.CharField(
         choices=AUTH_CHOICES,
-        verbose_name='Auth Scheme',
+        verbose_name="Auth Scheme",
         max_length=6,
         default=None,
         blank=True,
-        null=True
+        null=True,
     )
     auth_key = EncryptedCharField(
-        verbose_name='Auth Key',
-        max_length=256,
-        blank=True,
-        null=True
+        verbose_name="Auth Key", max_length=256, blank=True, null=True
     )
     username = EncryptedCharField(
-        verbose_name='Username',
-        max_length=256,
-        blank=True,
-        null=True
+        verbose_name="Username", max_length=256, blank=True, null=True
     )
     password = EncryptedCharField(
-        verbose_name='Password',
-        max_length=256,
-        blank=True,
-        null=True
+        verbose_name="Password", max_length=256, blank=True, null=True
     )
     configurations = EncryptedJSONField(blank=True, default=None)
     objects = RouterConfigurationManager()
@@ -181,17 +184,17 @@ class RouterConfiguration(ConfigurationModel):
         Addition of class names.
         """
 
-        verbose_name = 'Router Configuration'
-        verbose_name_plural = 'Router Configurations'
+        verbose_name = "Router Configuration"
+        verbose_name_plural = "Router Configurations"
 
     def __str__(self):
         """
         Return string representation for class instance.
         """
-        return '{id} - {backend} - {enabled}'.format(
+        return "{id} - {backend} - {enabled}".format(
             id=self.pk,
             backend=self.backend_name,
-            enabled='Enabled' if self.enabled else 'Disabled'
+            enabled="Enabled" if self.enabled else "Disabled",
         )
 
     @classmethod
@@ -255,7 +258,7 @@ class RouterConfiguration(ConfigurationModel):
             dict
         """
         if not self.configurations:
-            return {'host_configurations': {}}
+            return {"host_configurations": {}}
 
         is_allowed = self._match_event_for_host(original_event, self.configurations)
 
@@ -275,7 +278,7 @@ class RouterConfiguration(ConfigurationModel):
         Returns:
             bool
         """
-        for key, value in host_config.get('match_params', {}).items():
+        for key, value in host_config.get("match_params", {}).items():
             original_event_value = get_value_from_dotted_path(original_event, key)
             if isinstance(value, list):
                 matched = False
@@ -302,7 +305,5 @@ class RouterConfiguration(ConfigurationModel):
         try:
             return bool(re.compile(str(regex_exp))) and re.search(regex_exp, value_str)
         except TypeError as err:
-            logger.info(
-                        'Invalid regex %s with error: %s', regex_exp, err
-                    )
+            logger.info("Invalid regex %s with error: %s", regex_exp, err)
             return False

--- a/event_routing_backends/processors/mixins/base_transformer.py
+++ b/event_routing_backends/processors/mixins/base_transformer.py
@@ -133,11 +133,11 @@ class BaseTransformerMixin:
         #
         # Prefer user id to username, since usernames can change (via retirement) and usernames can
         # require more database lookups (again, for finding retired users).
-        username_or_id = self.get_data("data.user_id") or self.get_data("data.username")
-        if not username_or_id:
-            username_or_id = self.get_data("user_id") or self.get_data("username")
+        id_or_username = self.get_data("data.user_id") or self.get_data("data.username")
+        if not id_or_username:
+            id_or_username = self.get_data("user_id") or self.get_data("username")
 
-        return username_or_id
+        return id_or_username
 
     def extract_sessionid(self):
         """

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -8,6 +8,7 @@ in multiple test modules (i.e. factoryboy factories, base test classes).
 
 So this package is the place to put them.
 """
+
 import sys
 from unittest import mock
 
@@ -18,36 +19,41 @@ def _mock_third_party_modules():
     """
     # mock external_user_ids module
     external_id = mock.MagicMock()
-    external_id.external_user_id = '32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb'
+    external_id.external_user_id = "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     external_user_ids_module = mock.MagicMock()
-    external_user_ids_module.ExternalId.add_new_user_id.return_value = (external_id, True)
-    external_user_ids_module.ExternalIdType.XAPI = 'xapi'
-    sys.modules['openedx.core.djangoapps.external_user_ids.models'] = external_user_ids_module
+    external_user_ids_module.ExternalId.add_new_user_id.return_value = (
+        external_id,
+        True,
+    )
+    external_user_ids_module.ExternalIdType.XAPI = "xapi"
+    sys.modules["openedx.core.djangoapps.external_user_ids.models"] = (
+        external_user_ids_module
+    )
 
     # mock course
     mocked_course = {
-        'display_name': 'Demonstration Course',
+        "display_name": "Demonstration Course",
     }
 
     mocked_courses = mock.MagicMock()
     mocked_courses.get_course_overviews.return_value = [mocked_course]
-    sys.modules['openedx.core.djangoapps.content.course_overviews.api'] = mocked_courses
+    sys.modules["openedx.core.djangoapps.content.course_overviews.api"] = mocked_courses
 
     # mock opaque keys module
     mocked_keys = mock.MagicMock()
-    sys.modules['opaque_keys.edx.keys'] = mocked_keys
+    sys.modules["opaque_keys.edx.keys"] = mocked_keys
 
     # mock retired user
     mocked_user = mock.MagicMock()
-    mocked_user.username = 'edx_retired'
-    mocked_user.email = 'edx_retired@example.com'
+    mocked_user.username = "edx"
+    mocked_user.email = "edx@example.com"
     mocked_models = mock.MagicMock()
     mocked_models.get_potentially_retired_user_by_username.return_value = mocked_user
-    sys.modules['common.djangoapps.student.models'] = mocked_models
+    sys.modules["common.djangoapps.student.models"] = mocked_models
 
 
 def mocked_course_reverse(_, kwargs):
     """
     Return the reverse method to return course root URL.
     """
-    return '/courses/{}/'.format(kwargs.get('course_id'))
+    return "/courses/{}/".format(kwargs.get("course_id"))


### PR DESCRIPTION
**Description:** In some cases the context user and the data user are different, such as when an instructor enrolls a learner through the instructor dashboard. This change ensures that the data user is checked first, since that should be the "actor" for our purposes. It also changes search order to look for user id before username for performance reasons.

Closes: #508 

**Testing instructions:**

1. Check out this branch
2. Enroll a new test user in a course using the instructor dashboard
3. Observe the tracking logs show different users in `context` and `data`
4. Confirm that the correct user (the new test user) is present in the xAPI statement and not the instructor

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:**
It is possible that some events besides enrollments may have different users after this change, but I cannot think of a case where we would want the context user over the data user. Still, it's possible we want that somewhere.
