### PR TITLE
Fix docstring for completion events transformer

### DIFF
--- a/event_routing_backends/processors/xapi/event_transformers/completion_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/completion_events.py
@@ -1,5 +1,5 @@
 """
-Transformers for forum related events.
+Transformers for completion related events.
 """
 from tincan import Activity, ActivityDefinition, Extensions, LanguageMap, Result, Verb
 


### PR DESCRIPTION
Fix the naming error docstring. ('forum' to 'completion')

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
